### PR TITLE
fix: swift error interop for publishTransaction

### DIFF
--- a/DashSync/shared/Models/Managers/Chain Managers/DSTransactionManager.h
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSTransactionManager.h
@@ -75,7 +75,7 @@ typedef void (^DSTransactionRequestRelayCompletionBlock)(DSTransaction *tx, DSPa
 
 - (DSBloomFilter *)transactionsBloomFilterForPeer:(DSPeer *)peer;
 
-- (void)publishTransaction:(DSTransaction *)transaction completion:(void (^)(NSError *error))completion;
+- (void)publishTransaction:(DSTransaction *)transaction completion:(void (^)(NSError * _Nullable error))completion;
 
 - (void)confirmPaymentRequest:(DSPaymentRequest *)paymentRequest usingUserBlockchainIdentity:(DSBlockchainIdentity *_Nullable)blockchainIdentity fromAccount:(DSAccount *)account acceptInternalAddress:(BOOL)acceptInternalAddress acceptReusingAddress:(BOOL)acceptReusingAddress addressIsFromPasteboard:(BOOL)addressIsFromPasteboard requiresSpendingAuthenticationPrompt:(BOOL)requiresSpendingConfirmationPrompt
     keepAuthenticatedIfErrorAfterAuthentication:(BOOL)keepAuthenticatedIfErrorAfterAuthentication

--- a/DashSync/shared/Models/Managers/Chain Managers/DSTransactionManager.m
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSTransactionManager.m
@@ -175,7 +175,7 @@
     }
 }
 
-- (void)publishTransaction:(DSTransaction *)transaction completion:(void (^)(NSError *error))completion {
+- (void)publishTransaction:(DSTransaction *)transaction completion:(void (^)(NSError * _Nullable error))completion {
 #if DEBUG
     DSLogPrivate(@"[DSTransactionManager] publish transaction %@ %@", transaction, transaction.toData);
 #else


### PR DESCRIPTION
The error in `publishTransaction` is nullable but not marked as such. This makes it impossible to nil-check in Swift.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
manually


## Breaking Changes
n/a


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone