### PR TITLE
fix: wrong currency code returned from fiatCurrencyString

### DIFF
--- a/DashSync/shared/Models/Managers/Service Managers/DSPriceManager.m
+++ b/DashSync/shared/Models/Managers/Service Managers/DSPriceManager.m
@@ -501,7 +501,13 @@
     if (n == nil) {
         return DSLocalizedString(@"Updating Price", @"Updating Price");
     }
-    return [self.localFormat stringFromNumber:n];
+    
+    NSString *saved = self.localFormat.currencyCode;
+    self.localFormat.currencyCode = currencyCode;
+    NSString *formatted = [self.localFormat stringFromNumber:n];
+    self.localFormat.currencyCode = saved;
+    
+    return formatted;
 }
 
 - (NSString *)localCurrencyStringForBitcoinAmount:(int64_t)amount {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When `fiatCurrencyString` is called with a custom currency code, the returned amount is calculated correctly but the currency code is wrong - it is set to the local currency code.


## What was done?
To format the currency correctly, the `localFormat.currencyCode` is changed before formatting and then restored to the original value.


## How Has This Been Tested?
manually


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone