### PR TITLE
feat: Introduce a method to sign a tx without entering pin

### DIFF
--- a/DashSync/shared/Models/Derivation Paths/DSCreditFundingDerivationPath.m
+++ b/DashSync/shared/Models/Derivation Paths/DSCreditFundingDerivationPath.m
@@ -77,7 +77,7 @@
     NSUInteger index = [self indexOfKnownAddress:[[transaction inputAddresses] firstObject]];
 
     @autoreleasepool { // @autoreleasepool ensures sensitive data will be dealocated immediately
-        self.wallet.seedRequestBlock(authprompt, MASTERNODE_COST, ^void(NSData *_Nullable seed, BOOL cancelled) {
+        self.wallet.secureSeedRequestBlock(authprompt, MASTERNODE_COST, ^void(NSData *_Nullable seed, BOOL cancelled) {
             if (!seed) {
                 if (completion) completion(NO, cancelled);
             } else {

--- a/DashSync/shared/Models/Derivation Paths/DSMasternodeHoldingsDerivationPath.m
+++ b/DashSync/shared/Models/Derivation Paths/DSMasternodeHoldingsDerivationPath.m
@@ -49,7 +49,7 @@
     NSUInteger index = [self indexOfKnownAddress:[[transaction inputAddresses] firstObject]];
 
     @autoreleasepool { // @autoreleasepool ensures sensitive data will be dealocated immediately
-        self.wallet.seedRequestBlock(authprompt, MASTERNODE_COST, ^void(NSData *_Nullable seed, BOOL cancelled) {
+        self.wallet.secureSeedRequestBlock(authprompt, MASTERNODE_COST, ^void(NSData *_Nullable seed, BOOL cancelled) {
             if (!seed) {
                 if (completion) completion(NO, cancelled);
             } else {

--- a/DashSync/shared/Models/Wallet/DSAccount.h
+++ b/DashSync/shared/Models/Wallet/DSAccount.h
@@ -170,7 +170,25 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 
 
 - (DSTransaction *)updateTransaction:(DSTransaction *)transaction forAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee sortType:(DSTransactionSortType)sortType;
-// sign any inputs in the given transaction that can be signed using private keys from the wallet
+
+/// Sign any inputs in the given transaction that can be signed using private keys from the wallet
+///
+/// - Parameters:
+///   - transaction: Instanct of `DSTransaction` you want to sign
+///   - completion: Completion block that has type `TransactionValidityCompletionBlock`
+///
+/// - Note: Using this method to sign a tx doesn't present pin controller, use this method carefully from UI
+///
+- (void)signTransaction:(DSTransaction *)transaction completion:(_Nonnull TransactionValidityCompletionBlock)completion;
+
+/// Sign any inputs in the given transaction that can be signed using private keys from the wallet
+///
+/// - Parameters:
+///   - transaction: Instanct of `DSTransaction` you want to sign
+///   - completion: Completion block that has type `TransactionValidityCompletionBlock`
+///
+/// - Note: Using this method to sign a tx presents pin controller for auth purpose
+///
 - (void)signTransaction:(DSTransaction *)transaction withPrompt:(NSString *_Nullable)authprompt completion:(_Nonnull TransactionValidityCompletionBlock)completion;
 
 // true if the given transaction is associated with the account (even if it hasn't been registered), false otherwise

--- a/DashSync/shared/Models/Wallet/DSAccount.h
+++ b/DashSync/shared/Models/Wallet/DSAccount.h
@@ -174,7 +174,7 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 /// Sign any inputs in the given transaction that can be signed using private keys from the wallet
 ///
 /// - Parameters:
-///   - transaction: Instanct of `DSTransaction` you want to sign
+///   - transaction: Instance of `DSTransaction` you want to sign
 ///   - completion: Completion block that has type `TransactionValidityCompletionBlock`
 ///
 /// - Note: Using this method to sign a tx doesn't present pin controller, use this method carefully from UI
@@ -184,7 +184,7 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 /// Sign any inputs in the given transaction that can be signed using private keys from the wallet
 ///
 /// - Parameters:
-///   - transaction: Instanct of `DSTransaction` you want to sign
+///   - transaction: Instance of `DSTransaction` you want to sign
 ///   - completion: Completion block that has type `TransactionValidityCompletionBlock`
 ///
 /// - Note: Using this method to sign a tx presents pin controller for auth purpose

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -1248,18 +1248,11 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
 
 // MARK: = Signing
 
-// sign any inputs in the given transaction that can be signed using private keys from the wallet
-- (void)signTransaction:(DSTransaction *)transaction withPrompt:(NSString *_Nullable)authprompt completion:(TransactionValidityCompletionBlock)completion;
-{
-    NSParameterAssert(transaction);
-
-    if (_isViewOnlyAccount) return;
-    int64_t amount = [self amountSentByTransaction:transaction] - [self amountReceivedFromTransaction:transaction];
-
+- (NSArray *)usedDerivationPathsForTransaction:(DSTransaction *)transaction {
     NSMutableArray *usedDerivationPaths = [NSMutableArray array];
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         NSMutableOrderedSet *externalIndexes = [NSMutableOrderedSet orderedSet],
-                            *internalIndexes = [NSMutableOrderedSet orderedSet];
+        *internalIndexes = [NSMutableOrderedSet orderedSet];
         for (NSString *addr in transaction.inputAddresses) {
             if (!(derivationPath.type == DSDerivationPathType_ClearFunds || derivationPath.type == DSDerivationPathType_AnonymousFunds)) continue;
             if ([derivationPath isKindOfClass:[DSFundsDerivationPath class]]) {
@@ -1279,9 +1272,56 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
             [usedDerivationPaths addObject:@{@"derivationPath": derivationPath, @"externalIndexes": externalIndexes, @"internalIndexes": internalIndexes}];
         }
     }
+}
+
+- (void)signTransaction:(DSTransaction *)transaction completion:(_Nonnull TransactionValidityCompletionBlock)completion {
+    NSParameterAssert(transaction);
+
+    if (_isViewOnlyAccount) return;
+
+    int64_t amount = [self amountSentByTransaction:transaction] - [self amountReceivedFromTransaction:transaction];
+    NSArray *usedDerivationPaths = [self usedDerivationPathsForTransaction:transaction];
 
     @autoreleasepool { // @autoreleasepool ensures sensitive data will be dealocated immediately
-        self.wallet.seedRequestBlock(authprompt, (amount > 0) ? amount : 0, ^void(NSData *_Nullable seed, BOOL cancelled) {
+        self.wallet.seedRequestBlock(^void(NSData *_Nullable seed, BOOL cancelled) {
+            if (!seed) {
+                if (completion) completion(NO, YES);
+            } else {
+                NSMutableArray *privkeys = [NSMutableArray array];
+                for (NSDictionary *dictionary in usedDerivationPaths) {
+                    DSDerivationPath *derivationPath = dictionary[@"derivationPath"];
+                    NSMutableOrderedSet *externalIndexes = dictionary[@"externalIndexes"],
+                    *internalIndexes = dictionary[@"internalIndexes"];
+                    if ([derivationPath isKindOfClass:[DSFundsDerivationPath class]]) {
+                        DSFundsDerivationPath *fundsDerivationPath = (DSFundsDerivationPath *)derivationPath;
+                        [privkeys addObjectsFromArray:[fundsDerivationPath privateKeys:externalIndexes.array internal:NO fromSeed:seed]];
+                        [privkeys addObjectsFromArray:[fundsDerivationPath privateKeys:internalIndexes.array internal:YES fromSeed:seed]];
+                    } else if ([derivationPath isKindOfClass:[DSIncomingFundsDerivationPath class]]) {
+                        DSIncomingFundsDerivationPath *incomingFundsDerivationPath = (DSIncomingFundsDerivationPath *)derivationPath;
+                        [privkeys addObjectsFromArray:[incomingFundsDerivationPath privateKeys:externalIndexes.array fromSeed:seed]];
+                    } else {
+                        NSAssert(FALSE, @"The derivation path must be a normal or incoming funds derivation path");
+                    }
+                }
+
+                BOOL signedSuccessfully = [transaction signWithPrivateKeys:privkeys];
+                if (completion) completion(signedSuccessfully, NO);
+            }
+        });
+    }
+}
+
+// sign any inputs in the given transaction that can be signed using private keys from the wallet
+- (void)signTransaction:(DSTransaction *)transaction withPrompt:(NSString *_Nullable)authprompt completion:(TransactionValidityCompletionBlock)completion {
+    NSParameterAssert(transaction);
+
+    if (_isViewOnlyAccount) return;
+
+    int64_t amount = [self amountSentByTransaction:transaction] - [self amountReceivedFromTransaction:transaction];
+    NSArray *usedDerivationPaths = [self usedDerivationPathsForTransaction:transaction];
+
+    @autoreleasepool { // @autoreleasepool ensures sensitive data will be dealocated immediately
+        self.wallet.secureSeedRequestBlock(authprompt, (amount > 0) ? amount : 0, ^void(NSData *_Nullable seed, BOOL cancelled) {
             if (!seed) {
                 if (completion) completion(NO, YES);
             } else {
@@ -1317,7 +1357,7 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
     for (DSTransaction *transaction in transactions) {
         amount += [self amountSentByTransaction:transaction] - [self amountReceivedFromTransaction:transaction];
     }
-    self.wallet.seedRequestBlock(authprompt, (amount > 0) ? amount : 0, ^void(NSData *_Nullable seed, BOOL cancelled) {
+    self.wallet.secureSeedRequestBlock(authprompt, (amount > 0) ? amount : 0, ^void(NSData *_Nullable seed, BOOL cancelled) {
         for (DSTransaction *transaction in transactions) {
             NSMutableArray *usedDerivationPaths = [NSMutableArray array];
             for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -1250,6 +1250,7 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
 
 - (NSArray *)usedDerivationPathsForTransaction:(DSTransaction *)transaction {
     NSMutableArray *usedDerivationPaths = [NSMutableArray array];
+
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         NSMutableOrderedSet *externalIndexes = [NSMutableOrderedSet orderedSet],
         *internalIndexes = [NSMutableOrderedSet orderedSet];
@@ -1272,6 +1273,8 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
             [usedDerivationPaths addObject:@{@"derivationPath": derivationPath, @"externalIndexes": externalIndexes, @"internalIndexes": internalIndexes}];
         }
     }
+
+    return usedDerivationPaths;
 }
 
 - (void)signTransaction:(DSTransaction *)transaction completion:(_Nonnull TransactionValidityCompletionBlock)completion {

--- a/DashSync/shared/Models/Wallet/DSWallet+Protected.h
+++ b/DashSync/shared/Models/Wallet/DSWallet+Protected.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) SeedRequestBlock seedRequestBlock;
 
+@property (nonatomic, strong) SecureSeedRequestBlock secureSeedRequestBlock;
+
 @property (nonatomic, readonly) BOOL hasAnExtendedPublicKeyMissing;
 
 @property (nonatomic, strong) NSData *transientDerivedKeyData;

--- a/DashSync/shared/Models/Wallet/DSWallet.h
+++ b/DashSync/shared/Models/Wallet/DSWallet.h
@@ -30,7 +30,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^SeedCompletionBlock)(NSData *_Nullable seed, BOOL cancelled);
-typedef void (^SeedRequestBlock)(NSString *_Nullable authprompt, uint64_t amount, _Nullable SeedCompletionBlock seedCompletion);
+typedef void (^SeedRequestBlock)(_Nullable SeedCompletionBlock seedCompletion);
+typedef void (^SecureSeedRequestBlock)(NSString *_Nullable authprompt, uint64_t amount, _Nullable SeedCompletionBlock seedCompletion);
 
 FOUNDATION_EXPORT NSString *_Nonnull const DSWalletBalanceDidChangeNotification;
 

--- a/DashSync/shared/Models/Wallet/DSWallet.m
+++ b/DashSync/shared/Models/Wallet/DSWallet.m
@@ -802,7 +802,7 @@
 
 - (NSString *)seedPhraseIfAuthenticated {
     if (![DSAuthenticationManager sharedInstance].usesAuthentication || [DSAuthenticationManager sharedInstance].didAuthenticate) {
-        [self seedPhrase];
+        return [self seedPhrase];
     }
 
     return nil;

--- a/DashSync/shared/Models/Wallet/DSWallet.m
+++ b/DashSync/shared/Models/Wallet/DSWallet.m
@@ -803,17 +803,13 @@
 - (NSString *)seedPhraseIfAuthenticated {
     if (![DSAuthenticationManager sharedInstance].usesAuthentication || [DSAuthenticationManager sharedInstance].didAuthenticate) {
         [self seedPhrase];
-    } else {
-        return nil;
     }
+
+    return nil;
 }
 
 - (NSString *)seedPhrase {
-    if (![DSAuthenticationManager sharedInstance].usesAuthentication || [DSAuthenticationManager sharedInstance].didAuthenticate) {
-        return getKeychainString(self.mnemonicUniqueID, nil);
-    } else {
-        return nil;
-    }
+    return getKeychainString(self.mnemonicUniqueID, nil);
 }
 
 // authenticates user and returns seedPhrase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Introduce a method to sign a tx without entering pin

## What was done?
<!--- Describe your changes in detail -->
- [x] Introduce `SecureSeedRequestBlock` and use it when we want to enter pin
- [x] `SeedRequestBlock` now retrieves seed without pin
- [x] Add new method into `DSAccount` to sign tx without entering pin
- [x] Reflect all changes above


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone