### PR TITLE
feat(ui): Present view controllers from auth manager on top of the current context

### DIFF
--- a/DashSync/shared/Models/Managers/Service Managers/Auth/DSAuthenticationManager.m
+++ b/DashSync/shared/Models/Managers/Service Managers/Auth/DSAuthenticationManager.m
@@ -958,8 +958,13 @@ NSString *const DSApplicationTerminationRequestNotification = @"DSApplicationTer
                  animated:(BOOL)animated
                completion:(void (^_Nullable)(void))completion {
     UIWindow *window = [UIWindow keyWindow];
+    
     UIViewController *presentingController = [window ds_presentingViewController];
     NSParameterAssert(presentingController);
+    
+    //NOTE: Make sure we present anything on top of the current context
+    controller.modalPresentationStyle = UIModalPresentationOverFullScreen;
+    
     [presentingController presentViewController:controller animated:animated completion:completion];
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently we presenting view controller from auth manager inside the current view controller and it leads to wrong layout of the presenting controller. In this PR we made a small fix in order to present the presenting view controller on top of the screen.

## What was done?
<!--- Describe your changes in detail -->
- [x] Set modalPresentationStyle property of presenting view controller to UIModalPresentationOverFullScreen

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone