### PR TITLE
fix: change key storage locations for bls basic and ed25519

### DIFF
--- a/DashSync/shared/Models/Managers/Chain Managers/DSKeyManager.m
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSKeyManager.m
@@ -267,8 +267,8 @@
     switch (keyType) {
         case KeyKind_ECDSA: return @"";
         case KeyKind_BLS: return @"_BLS_";
-        case KeyKind_BLSBasic: return @"_BLS_";
-        case KeyKind_ED25519: return @"_ED_";
+        case KeyKind_BLSBasic: return @"_BLS_B_";
+        case KeyKind_ED25519: return @"_ED25519_";
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
Keychain locations for BLS (basic) and ED 25519 has changed 

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needed for those who already generate keys with wrong derivation scheme and stored them in keychain

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone