### PR TITLE
feat(coinjoin): availableCoins method

### DIFF
--- a/DashSync/shared/Models/Chain/DSChainConstants.h
+++ b/DashSync/shared/Models/Chain/DSChainConstants.h
@@ -82,3 +82,5 @@
 #define MAX_FEE_PER_B 1000         // slightly higher than a 1000bit fee on a 191byte tx
 
 #define HEADER_WINDOW_BUFFER_TIME (WEEK_TIME_INTERVAL / 2) //This is about the time if we consider a block every 10 mins (for 500 blocks)
+ 
+#define COINBASE_MATURITY 100 // Coinbase transaction outputs can only be spent after this number of new blocks (network rule)

--- a/DashSync/shared/Models/CoinJoin/DSCoinControl.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinControl.h
@@ -37,7 +37,8 @@ typedef NS_ENUM(NSInteger, CoinType) {
 @property (nonatomic, assign) BOOL overrideFeeRate;
 @property (nonatomic, assign) BOOL avoidPartialSpends;
 @property (nonatomic, assign) BOOL avoidAddressReuse;
-@property (nonatomic, assign) int minDepth;
+@property (nonatomic, assign) int32_t minDepth;
+@property (nonatomic, assign) int32_t maxDepth;
 @property (nonatomic, assign) uint64_t feeRate;
 @property (nonatomic, assign) uint64_t discardFeeRate;
 @property (nonatomic, strong) NSNumber *confirmTarget;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
@@ -17,6 +17,8 @@
 
 #import <Foundation/Foundation.h>
 #import "DSChain.h"
+#import "DSTransactionOutput.h"
+#import "DSCoinControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,8 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithChain:(DSChain *)chain;
 
-- (BOOL)hasCollateralInputs:(BOOL)onlyConfirmed;
 - (BOOL)isMineInput:(UInt256)txHash index:(uint32_t)index;
+- (BOOL)hasCollateralInputs:(WalletEx *)walletEx onlyConfirmed:(BOOL)onlyConfirmed;
+- (NSArray<DSTransactionOutput *> *) availableCoins:(WalletEx *)walletEx onlySafe:(BOOL)onlySafe coinControl:(DSCoinControl *_Nullable)coinControl minimumAmount:(uint64_t)minimumAmount maximumAmount:(uint64_t)maximumAmount minimumSumAmount:(uint64_t)minimumSumAmount maximumCount:(uint64_t)maximumCount;
 
 @end
 

--- a/DashSync/shared/Models/Transactions/Base/DSTransaction.h
+++ b/DashSync/shared/Models/Transactions/Base/DSTransaction.h
@@ -104,6 +104,7 @@ typedef NS_ENUM(NSInteger, DSTransactionSortType)
 
 @property (nonatomic, readonly) NSString *longDescription;
 @property (nonatomic, readonly) BOOL isCoinbaseClassicTransaction;
+@property (nonatomic, readonly) BOOL isImmatureCoinBase;
 @property (nonatomic, readonly) BOOL isCreditFundingTransaction;
 @property (nonatomic, readonly) UInt256 creditBurnIdentityIdentifier;
 

--- a/DashSync/shared/Models/Transactions/Base/DSTransaction.m
+++ b/DashSync/shared/Models/Transactions/Base/DSTransaction.m
@@ -379,6 +379,19 @@
     }
 }
 
+- (BOOL)isImmatureCoinBase {
+    // note GetBlocksToMaturity is 0 for non-coinbase tx
+    return [self getBlocksToMaturity] > 0;
+}
+
+- (int32_t)getBlocksToMaturity {
+    if (![self isCoinbaseClassicTransaction])
+        return 0;
+    
+    uint32_t chainDepth = [self confirmations];
+    return MAX(0, (COINBASE_MATURITY + 1) - chainDepth);
+}
+
 - (BOOL)isCreditFundingTransaction {
     for (DSTransactionOutput *output in self.outputs) {
         NSData *script = output.outScript;

--- a/DashSync/shared/Models/Wallet/DSAccount.h
+++ b/DashSync/shared/Models/Wallet/DSAccount.h
@@ -215,6 +215,8 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 // true if no previous account transaction spends any of the given transaction's inputs, and no inputs are invalid
 - (BOOL)transactionIsValid:(DSTransaction *)transaction;
 
+- (BOOL)isSpent:(NSValue *)output;
+
 // returns input value if no previous account transaction spends this input, and the input is valid, -1 otherwise.
 - (int64_t)inputValue:(UInt256)txHash inputIndex:(uint32_t)index;
 

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -1502,6 +1502,10 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
     }
 }
 
+- (BOOL)isSpent:(NSValue *)output {
+    return [self.spentOutputs containsObject:output];
+}
+
 - (int64_t)inputValue:(UInt256)txHash inputIndex:(uint32_t)index {
     NSValue *hash = uint256_obj(txHash);
     DSTransaction *tx = self.allTx[hash];

--- a/Example/DashSync/DSCoinJoinViewController.m
+++ b/Example/DashSync/DSCoinJoinViewController.m
@@ -117,13 +117,7 @@
         _walletEx = register_wallet_ex(_options, getTransaction, destroyTransaction, isMineInput, AS_RUST(self.wrapper));
     }
     
-    DSUTXO o;
-    for (NSValue *utxo in self.wrapper.chain.wallets.firstObject.unspentOutputs) {
-        [utxo getValue:&o];
-        DSTransaction *tx = [self.wrapper.chain transactionForHash:o.hash];
-        int32_t result = call_wallet_ex(_walletEx, (uint8_t (*)[32])&(o.hash.u8), (uint32_t)o.n);
-        DSLog(@"[OBJ-C] CoinJoin: get_real_outpoint_coinjoin_rounds for %llu: %d", tx.outputs[o.n].amount, result);
-    }
+    [self.wrapper hasCollateralInputs:_walletEx onlyConfirmed:true];
 }
 
 ///
@@ -198,16 +192,16 @@ bool isMineInput(uint8_t (*tx_hash)[32], uint32_t index, const void *context) {
     return result;
 }
 
-bool hasCollateralInputs(BOOL onlyConfirmed, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: hasCollateralInputs");
-    BOOL result = NO;
-    
-    @synchronized (context) {
-        result = [AS_OBJC(context) hasCollateralInputs:onlyConfirmed];
-    }
-    
-    return result;
-}
+//bool hasCollateralInputs(BOOL onlyConfirmed, const void *context) {
+//    DSLog(@"[OBJ-C CALLBACK] CoinJoin: hasCollateralInputs");
+//    BOOL result = NO;
+//    
+//    @synchronized (context) {
+//        result = [AS_OBJC(context) hasCollateralInputs:onlyConfirmed];
+//    }
+//    
+//    return result;
+//}
 
 void destroyInputValue(InputValue *value) {
     DSLog(@"[OBJ-C] CoinJoin: 💀 InputValue");


### PR DESCRIPTION
## Issue being fixed or feature implemented
For various CoinJoin functions we need the `availableCoins` function which would count outputs suitable for the required purpose.
https://github.com/dashpay/dashj/blob/feature-coinjoin/core/src/main/java/org/bitcoinj/wallet/WalletEx.java#L739
https://github.com/dashpay/dash/blob/master/src/wallet/wallet.cpp#L2536

## What was done?
- `availableCoins` method
- `hasCollateralInputs` method


## How Has This Been Tested?
N/A


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone