### PR TITLE
feat(coinjoin): recalculate balance

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
@@ -16,25 +16,41 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "DSChain.h"
+#import "DSTransactionOutput.h"
+#import "DSCoinControl.h"
+#import "DSCompactTallyItem.h"
+#import "DSCoinJoinManager.h"
+#import "DSCoinJoinWrapper.h"
 #import "DSMasternodeGroup.h"
-#import "DSChainManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class DSCoinJoinWrapper;
-
 @interface DSCoinJoinManager : NSObject
 
-@property (nonatomic, strong, nullable) DSChainManager *chainManager;
-@property (nonatomic, strong, nullable) DSCoinJoinWrapper *wrapper;
+@property (nonatomic, assign, nullable) DSChainManager *chainManager;
 @property (nonatomic, strong, nullable) DSMasternodeGroup *masternodeGroup;
-
-@property (nonatomic, assign, nullable) WalletEx *walletEx;
-@property (nonatomic, assign, nullable) CoinJoinClientManager *clientManager;
 @property (nonatomic, assign, nullable) CoinJoinClientOptions *options;
+@property (nonatomic, assign) BOOL anonymizableTallyCachedNonDenom;
+@property (nonatomic, assign) BOOL anonymizableTallyCached;
+@property (nonatomic, strong) DSChain *chain;
+@property (nonatomic, weak, nullable) DSCoinJoinWrapper *wrapper;
 
-- (instancetype)initWithChainManager:(DSChainManager *)chainManager;
-- (void)runCoinJoin;
+- (instancetype)initWithWrapper:(DSCoinJoinWrapper *)coinJoinWrapper chainManager:(DSChainManager *)chainManager;
+
+- (BOOL)isMineInput:(UInt256)txHash index:(uint32_t)index;
+- (NSArray<DSInputCoin *> *) availableCoins:(WalletEx *)walletEx onlySafe:(BOOL)onlySafe coinControl:(DSCoinControl *_Nullable)coinControl minimumAmount:(uint64_t)minimumAmount maximumAmount:(uint64_t)maximumAmount minimumSumAmount:(uint64_t)minimumSumAmount maximumCount:(uint64_t)maximumCount;
+- (NSArray<DSCompactTallyItem *> *)selectCoinsGroupedByAddresses:(WalletEx *)walletEx skipDenominated:(BOOL)skipDenominated anonymizable:(BOOL)anonymizable skipUnconfirmed:(BOOL)skipUnconfirmed maxOupointsPerAddress:(int32_t)maxOupointsPerAddress;
+- (uint32_t)countInputsWithAmount:(uint64_t)inputAmount;
+- (NSString *)freshAddress:(BOOL)internal;
+- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs onPublished:(void (^)(NSError * _Nullable error))onPublished;
+- (DSSimplifiedMasternodeEntry *)masternodeEntryByHash:(UInt256)hash;
+- (uint64_t)validMNCount;
+- (DSMasternodeList *)mnList;
+- (BOOL)isMasternodeOrDisconnectRequested;
+- (void)sendAcceptMessage:(NSData *)message withPeerIP:(UInt128)address port:(uint16_t)port;
+- (uint64_t)getDenominatedBalance;
+- (uint64_t)getAnonymizedBalance;
 
 @end
 

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
@@ -34,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL anonymizableTallyCachedNonDenom;
 @property (nonatomic, assign) BOOL anonymizableTallyCached;
 @property (nonatomic, strong) DSChain *chain;
-@property (nonatomic, weak, nullable) DSCoinJoinWrapper *wrapper;
+@property (nonatomic, strong, nullable) DSCoinJoinWrapper *wrapper;
 
-- (instancetype)initWithWrapper:(DSCoinJoinWrapper *)coinJoinWrapper chainManager:(DSChainManager *)chainManager;
+- (instancetype)initWithChainManager:(DSChainManager *)chainManager;
 
 - (BOOL)isMineInput:(UInt256)txHash index:(uint32_t)index;
 - (NSArray<DSInputCoin *> *) availableCoins:(WalletEx *)walletEx onlySafe:(BOOL)onlySafe coinControl:(DSCoinControl *_Nullable)coinControl minimumAmount:(uint64_t)minimumAmount maximumAmount:(uint64_t)maximumAmount minimumSumAmount:(uint64_t)minimumSumAmount maximumCount:(uint64_t)maximumCount;
@@ -49,8 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (DSMasternodeList *)mnList;
 - (BOOL)isMasternodeOrDisconnectRequested;
 - (void)sendAcceptMessage:(NSData *)message withPeerIP:(UInt128)address port:(uint16_t)port;
-- (uint64_t)getDenominatedBalance;
-- (uint64_t)getAnonymizedBalance;
+- (Balance *)getBalance;
+- (void)runCoinJoin;
 
 @end
 

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
@@ -16,414 +16,457 @@
 //
 
 #import "DSCoinJoinManager.h"
-#import "DSWallet.h"
-#import "DSTransaction+CoinJoin.h"
-#import "DSTransactionOutput+CoinJoin.h"
-#import "DSSimplifiedMasternodeEntry+Mndiff.h"
-#import "DSMasternodeList+Mndiff.h"
+#import "DSTransaction.h"
+#import "DSTransactionOutput.h"
 #import "DSAccount.h"
+#import "DSCoinControl.h"
+#import "DSWallet.h"
+#import "BigIntTypes.h"
+#import "NSString+Bitcoin.h"
 #import "DSChainManager.h"
-#import "DSCoinJoinWrapper.h"
+#import "DSTransactionManager.h"
+#import "DSMasternodeManager.h"
+#import "DSCoinJoinAcceptMessage.h"
+#import "DSPeerManager.h"
 
-#define AS_OBJC(context) ((__bridge DSCoinJoinWrapper *)(context))
-#define AS_RUST(context) ((__bridge void *)(context))
+int32_t const DEFAULT_MIN_DEPTH = 0;
+int32_t const DEFAULT_MAX_DEPTH = 9999999;
 
 @implementation DSCoinJoinManager
 
-- (instancetype)initWithChainManager:(DSChainManager *)chainManager {
+- (instancetype)initWithWrapper:(DSCoinJoinWrapper *)coinJoinWrapper chainManager:(DSChainManager *)chainManager {
     self = [super init];
     if (self) {
         _chainManager = chainManager;
-        _wrapper = [[DSCoinJoinWrapper alloc] initWithManagers:self.chainManager coinJoinManager:self];
-        _masternodeGroup = [[DSMasternodeGroup alloc] init];
-        _wrapper.masternodeGroup = _masternodeGroup;
+        _wrapper = coinJoinWrapper;
     }
     return self;
 }
 
-- (void)runCoinJoin {
-    if (_options != NULL) {
-        free(_options);
-        _options = NULL;
+- (DSChain *)chain {
+    return self.chainManager.chain;
+}
+
+- (BOOL)isMineInput:(UInt256)txHash index:(uint32_t)index {
+    DSTransaction *tx = [self.chain transactionForHash:txHash];
+    DSAccount *account = [self.chain firstAccountThatCanContainTransaction:tx];
+    
+    if (index < tx.outputs.count) {
+        DSTransactionOutput *output = tx.outputs[index];
+        
+        if ([account containsAddress:output.address]) { // TODO: is it the same as isPubKeyMine?
+            return YES;
+        }
     }
     
-    _options = [self createOptions];
-    
-    DSLog(@"[OBJ-C] CoinJoin: register");
-    _walletEx = register_wallet_ex(AS_RUST(self.wrapper), _options, getTransaction, signTransaction, destroyTransaction, isMineInput, commitTransaction, masternodeByHash, destroyMasternodeEntry, validMNCount, isBlockchainSynced, freshCoinJoinAddress, countInputsWithAmount, availableCoins, destroyGatheredOutputs, selectCoinsGroupedByAddresses, destroySelectedCoins, isMasternodeOrDisconnectRequested, sendMessage);
-    _clientManager = register_client_manager(AS_RUST(self.wrapper), _walletEx, _options, getMNList, destroyMNList, getInputValueByPrevoutHash, hasChainLock, destroyInputValue);
-    
-    DSLog(@"[OBJ-C] CoinJoin: call");
-    Balance *balance = [self getBalance];
-    
-    run_client_manager(_clientManager, *balance);
-//    DSLog(@"[OBJ-C] CoinJoin: do_automatic_denominating result: %llu", self.wrapper.balance_needs_anonymized);
-//    free(balance);
-    
-    
-    // Might be useful:
-//    - (DSPeer *)peerForLocation:(UInt128)IPAddress port:(uint16_t)port
-    
-//    if ([self.masternodeManager hasMasternodeAtLocation:IPAddress port:port]) {
-//        return DSPeerType_MasterNode;
-//    } else {
-//        return DSPeerType_FullNode;
-//    }
-
-//    - (instancetype)initWithSimplifiedMasternodeEntry:(DSSimplifiedMasternodeEntry *)simplifiedMasternodeEntry
-    
-//    - (void)sendRequest:(DSMessageRequest *)request
+    return NO;
 }
 
-- (CoinJoinClientOptions *)createOptions {
-    CoinJoinClientOptions *options = malloc(sizeof(CoinJoinClientOptions));
-    options->enable_coinjoin = YES;
-    options->coinjoin_rounds = 1;
-    options->coinjoin_sessions = 1;
-    options->coinjoin_amount = DUFFS / 4; // 0.25 DASH
-    options->coinjoin_random_rounds = COINJOIN_RANDOM_ROUNDS;
-    options->coinjoin_denoms_goal = DEFAULT_COINJOIN_DENOMS_GOAL;
-    options->coinjoin_denoms_hardcap = DEFAULT_COINJOIN_DENOMS_HARDCAP;
-    options->coinjoin_multi_session = NO;
-    DSLog(@"[OBJ-C] CoinJoin: trusted balance: %llu", self.wrapper.chain.balance);
+- (NSArray<DSCompactTallyItem *> *)selectCoinsGroupedByAddresses:(WalletEx *)walletEx skipDenominated:(BOOL)skipDenominated anonymizable:(BOOL)anonymizable skipUnconfirmed:(BOOL)skipUnconfirmed maxOupointsPerAddress:(int32_t)maxOupointsPerAddress {
     
-    return options;
-}
-
--(Balance *)getBalance {
-    Balance *balance = malloc(sizeof(Balance));
-    balance->my_trusted = self.wrapper.chain.balance;
-    balance->my_immature = 0;
-    balance->anonymized = 0;
-    balance->my_untrusted_pending = 0;
-    balance->denominated_trusted = 0;
-    balance->denominated_untrusted_pending = 0;
-    balance->watch_only_trusted = 0;
-    balance->watch_only_untrusted_pending = 0;
-    balance->watch_only_immature = 0;
-    
-    return balance;
-}
-
-- (void)dealloc {
-    if (_options != NULL) {
-        free(_options);
-    }
-    
-    unregister_client_manager(_clientManager);
-    unregister_wallet_ex(_walletEx); // Unregister last
-}
-
-///
-/// MARK: Rust FFI callbacks
-///
-
-InputValue *getInputValueByPrevoutHash(uint8_t (*prevout_hash)[32], uint32_t index, const void *context) {
-    UInt256 txHash = *((UInt256 *)prevout_hash);
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: getInputValueByPrevoutHash");
-    InputValue *inputValue = NULL;
-    
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        inputValue = malloc(sizeof(InputValue));
-        DSWallet *wallet = wrapper.chain.wallets.firstObject;
-        int64_t value = [wallet inputValue:txHash inputIndex:index];
+    @synchronized(self) {
+        // Note: cache is checked in dash-shared-core.
+        
+        uint64_t smallestDenom = coinjoin_get_smallest_denomination();
+        NSMutableDictionary<NSData*, DSCompactTallyItem*> *mapTally = [[NSMutableDictionary alloc] init];
+        NSMutableSet<NSData *> *setWalletTxesCounted = [[NSMutableSet alloc] init];
+        
+        DSUTXO outpoint;
+        NSArray *utxos = self.chain.wallets.firstObject.unspentOutputs;
+        for (NSValue *value in utxos) {
+            [value getValue:&outpoint];
             
-        if (value != -1) {
-            inputValue->is_valid = TRUE;
-            inputValue->value = value;
-        } else {
-            inputValue->is_valid = FALSE;
+            if ([setWalletTxesCounted containsObject:uint256_data(outpoint.hash)]) {
+                continue;
+            }
+            
+            [setWalletTxesCounted addObject:uint256_data(outpoint.hash)];
+            DSTransaction *wtx = [self.chain transactionForHash:outpoint.hash];
+            
+            if (wtx == nil) {
+                continue;
+            }
+            
+            if (wtx.isCoinbaseClassicTransaction && [wtx getBlocksToMaturity] > 0) {
+                continue;
+            }
+            
+            DSAccount *account = [self.chain firstAccountThatCanContainTransaction:wtx];
+            BOOL isTrusted = wtx.instantSendReceived || [account transactionIsVerified:wtx];
+            
+            if (skipUnconfirmed && !isTrusted) {
+                continue;
+            }
+            
+            for (int32_t i = 0; i < wtx.outputs.count; i++) {
+                DSTransactionOutput *output = wtx.outputs[i];
+                NSData *txDest = output.outScript;
+                NSString *address = [NSString bitcoinAddressWithScriptPubKey:txDest forChain:self.chain];
+                
+                if (address == nil) {
+                    continue;
+                }
+                
+                if (![account containsAddress:output.address]) { // TODO: is it the same as isPubKeyMine?
+                    continue;
+                }
+                
+                DSCompactTallyItem *tallyItem = mapTally[txDest];
+                
+                if (maxOupointsPerAddress != -1 && tallyItem != nil && tallyItem.inputCoins.count >= maxOupointsPerAddress) {
+                    continue;
+                }
+
+                if (is_locked_coin(walletEx, (uint8_t (*)[32])(outpoint.hash.u8), (uint32_t)i)) {
+                    continue;
+                }
+                
+                if (skipDenominated && is_denominated_amount(output.amount)) {
+                    continue;
+                }
+                
+                if (anonymizable) {
+                    // ignore collaterals
+                    if (is_collateral_amount(output.amount)) {
+                        continue;
+                    }
+                    
+                    // ignore outputs that are 10 times smaller then the smallest denomination
+                    // otherwise they will just lead to higher fee / lower priority
+                    if (output.amount <= smallestDenom/10) {
+                        continue;
+                    }
+                    
+                    // ignore mixed
+                    if (is_fully_mixed(walletEx, (uint8_t (*)[32])(outpoint.hash.u8), (uint32_t)i)) {
+                        continue;
+                    }
+                }
+                
+                if (tallyItem == nil) {
+                    tallyItem = [[DSCompactTallyItem alloc] init];
+                    tallyItem.txDestination = txDest;
+                    mapTally[txDest] = tallyItem;
+                }
+                
+                tallyItem.amount += output.amount;
+                DSInputCoin *coin = [[DSInputCoin alloc] initWithTx:wtx index:i];
+                [tallyItem.inputCoins addObject:coin];
+            }
+        }
+
+        // construct resulting vector
+        // NOTE: vecTallyRet is "sorted" by txdest (i.e. address), just like mapTally
+        NSMutableArray<DSCompactTallyItem *> *vecTallyRet = [[NSMutableArray alloc] init];
+        
+        for (DSCompactTallyItem *item in mapTally.allValues) {
+            // TODO: (dashj) ignore this to get this dust back in
+            if (anonymizable && item.amount < smallestDenom) {
+                continue;
+            }
+            
+            [vecTallyRet addObject:item];
+        }
+
+        // Note: cache is assigned in dash-shared-core
+        
+        return vecTallyRet;
+    }
+}
+
+- (uint32_t)countInputsWithAmount:(uint64_t)inputAmount {
+    uint32_t total = 0;
+    
+    @synchronized(self) {
+        NSArray *unspent = self.chain.wallets.firstObject.unspentOutputs;
+        
+        DSUTXO outpoint;
+        for (uint32_t i = 0; i < unspent.count; i++) {
+            [unspent[i] getValue:&outpoint];
+            DSTransaction *tx = [self.chain transactionForHash:outpoint.hash];
+            
+            if (tx == NULL) {
+                continue;
+            }
+            
+            if (tx.outputs[outpoint.n].amount != inputAmount) {
+                continue;
+            }
+            
+            if (tx.confirmations < 0) {
+                continue;
+            }
+            
+            total++;
         }
     }
     
-    processor_destroy_block_hash(prevout_hash);
-    return inputValue;
+    return total;
 }
 
-
-bool hasChainLock(Block *block, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: hasChainLock");
-    BOOL hasChainLock = NO;
+- (NSArray<DSInputCoin *> *) availableCoins:(WalletEx *)walletEx onlySafe:(BOOL)onlySafe coinControl:(DSCoinControl *_Nullable)coinControl minimumAmount:(uint64_t)minimumAmount maximumAmount:(uint64_t)maximumAmount minimumSumAmount:(uint64_t)minimumSumAmount maximumCount:(uint64_t)maximumCount {
+    NSMutableArray<DSInputCoin *> *vCoins = [NSMutableArray array];
     
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        hasChainLock = [wrapper.chain blockHeightChainLocked:block->height];
-    }
-    
-    processor_destroy_block(block);
-    return hasChainLock;
-}
+    @synchronized(self) {
+        CoinType coinType = coinControl != nil ? coinControl.coinType : CoinType_AllCoins;
 
-Transaction *getTransaction(uint8_t (*tx_hash)[32], const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: getTransaction");
-    UInt256 txHash = *((UInt256 *)tx_hash);
-    Transaction *tx = NULL;
-    
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        DSTransaction *transaction = [wrapper.chain transactionForHash:txHash];
-
-        if (transaction) {
-            tx = [transaction ffi_malloc:wrapper.chain.chainType];
+        uint64_t total = 0;
+        // Either the WALLET_FLAG_AVOID_REUSE flag is not set (in which case we always allow), or we default to avoiding, and only in the case where a coin control object is provided, and has the avoid address reuse flag set to false, do we allow already used addresses
+        BOOL allowUsedAddresses = /* !IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE) || */ (coinControl != nil && !coinControl.avoidAddressReuse);
+        int32_t minDepth = coinControl != nil ? coinControl.minDepth : DEFAULT_MIN_DEPTH;
+        int32_t maxDepth = coinControl != nil ? coinControl.maxDepth : DEFAULT_MAX_DEPTH;
+        
+        for (DSTransaction *coin in [self getSpendableTXs]) {
+            UInt256 wtxid = coin.txHash;
+            DSAccount *account = [self.chain firstAccountThatCanContainTransaction:coin];
+            
+            if ([account transactionIsPending:coin]) {
+                continue;
+            }
+            
+            if (coin.isImmatureCoinBase) {
+                continue;
+            }
+            
+            BOOL safeTx = coin.instantSendReceived || [account transactionIsVerified:coin];
+            
+            if (onlySafe && !safeTx) {
+                continue;
+            }
+            
+            uint32_t depth = coin.confirmations;
+            
+            if (depth < minDepth || depth > maxDepth) {
+                continue;
+            }
+            
+            for (uint32_t i = 0; i < coin.outputs.count; i++) {
+                DSTransactionOutput *output = coin.outputs[i];
+                DSLog(@"[OBJ-C] CoinJoin: check output: %llu", output.amount);
+                uint64_t value = output.amount;
+                BOOL found = NO;
+                
+                if (coinType == CoinType_OnlyFullyMixed) {
+                    if (!is_denominated_amount(value)) {
+                        continue;
+                    }
+                    
+                    found = is_fully_mixed(walletEx, (uint8_t (*)[32])(wtxid.u8), (uint32_t)i);
+                } else if (coinType == CoinType_OnlyReadyToMix) {
+                    if (!is_denominated_amount(value)) {
+                        continue;
+                    }
+                    
+                    found = !is_fully_mixed(walletEx, (uint8_t (*)[32])(wtxid.u8), (uint32_t)i);
+                } else if (coinType == CoinType_OnlyNonDenominated) {
+                    if (is_collateral_amount(value)) {
+                        continue; // do not use collateral amounts
+                    }
+                    
+                    found = !is_denominated_amount(value);
+                } else if (coinType == CoinType_OnlyMasternodeCollateral) {
+                    found = value == 1000 * DUFFS;
+                } else if (coinType == CoinType_OnlyCoinJoinCollateral) {
+                    found = is_collateral_amount(value);
+                } else {
+                    found = YES;
+                }
+                
+                if (!found) {
+                    continue;
+                }
+                
+                if (value < minimumAmount || value > maximumAmount) {
+                    continue;
+                }
+                
+                NSValue *outputValue = dsutxo_obj(((DSUTXO){wtxid, i}));
+                
+                if (coinControl != nil && coinControl.hasSelected && !coinControl.allowOtherInputs && ![coinControl isSelected:outputValue]) {
+                    continue;
+                }
+                
+                if (is_locked_coin(walletEx, (uint8_t (*)[32])(wtxid.u8), (uint32_t)i) && coinType != CoinType_OnlyMasternodeCollateral) {
+                    continue;
+                }
+                
+                if ([account isSpent:outputValue]) {
+                    continue;
+                }
+                
+                if (output.address == nil || ![account containsAddress:output.address]) {
+                    continue;
+                }
+                
+                if (!allowUsedAddresses && [account transactionAddressAlreadySeenInOutputs:output.address]) {
+                    continue;
+                }
+                
+                [vCoins addObject:[[DSInputCoin alloc] initWithTx:coin index:i]];
+                
+                // Checks the sum amount of all UTXO's.
+                if (minimumSumAmount != MAX_MONEY) {
+                    total += value;
+                    
+                    if (total >= minimumSumAmount) {
+                        return vCoins;
+                    }
+                }
+                
+                // Checks the maximum number of UTXO's.
+                if (maximumCount > 0 && vCoins.count >= maximumCount) {
+                    return vCoins;
+                }
+            }
         }
     }
     
-    processor_destroy_block_hash(tx_hash);
-    return tx;
+    return vCoins;
 }
 
-bool isMineInput(uint8_t (*tx_hash)[32], uint32_t index, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: isMine");
-    UInt256 txHash = *((UInt256 *)tx_hash);
-    BOOL result = NO;
-    
-    @synchronized (context) {
-        result = [AS_OBJC(context) isMineInput:txHash index:index];
+- (BOOL)isCoinJoinOutput:(DSTransactionOutput *)output utxo:(DSUTXO)utxo {
+    if (!is_denominated_amount(output.amount)) {
+        return false;
     }
     
-    processor_destroy_block_hash(tx_hash);
-    return result;
+    if (!is_fully_mixed(_wrapper.walletEx, (uint8_t (*)[32])(utxo.hash.u8), (uint32_t)utxo.n)) {
+        return false;
+    }
+    
+    return [self.chain.wallets.firstObject.accounts.firstObject.coinJoinDerivationPath containsAddress:output.address];
 }
 
-GatheredOutputs* availableCoins(bool onlySafe, CoinControl coinControl, WalletEx *walletEx, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: hasCollateralInputs");
-    GatheredOutputs *gatheredOutputs;
+-(uint64_t)getDenominatedBalance {
+    NSMutableSet<NSData *> *setWalletTxesCounted = [[NSMutableSet alloc] init];
     
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        ChainType chainType = wrapper.chain.chainType;
-        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:&coinControl];
-        NSArray<DSInputCoin *> *coins = [wrapper availableCoins:walletEx onlySafe:onlySafe coinControl:cc minimumAmount:1 maximumAmount:MAX_MONEY minimumSumAmount:MAX_MONEY maximumCount:0];
+    DSUTXO outpoint;
+    NSArray *utxos = self.chain.wallets.firstObject.unspentOutputs;
+    for (NSValue *value in utxos) {
+        [value getValue:&outpoint];
         
-        gatheredOutputs = malloc(sizeof(GatheredOutputs));
-        InputCoin **coinsArray = malloc(coins.count * sizeof(InputCoin *));
-        
-        for (uintptr_t i = 0; i < coins.count; ++i) {
-            coinsArray[i] = [coins[i] ffi_malloc:chainType];
+        if ([setWalletTxesCounted containsObject:uint256_data(outpoint.hash)]) {
+            continue;
         }
         
-        gatheredOutputs->items = coinsArray;
-        gatheredOutputs->item_count = (uintptr_t)coins.count;
+        [setWalletTxesCounted addObject:uint256_data(outpoint.hash)];
+        DSTransaction *wtx = [self.chain transactionForHash:outpoint.hash];
     }
-    
-    return gatheredOutputs;
 }
 
-SelectedCoins* selectCoinsGroupedByAddresses(bool skipDenominated, bool anonymizable, bool skipUnconfirmed, int maxOupointsPerAddress, WalletEx* walletEx, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: selectCoinsGroupedByAddresses");
-    SelectedCoins *vecTallyRet;
+-(uint64_t)getAnonymizedBalance {
     
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        NSArray<DSCompactTallyItem *> *tempVecTallyRet = [wrapper selectCoinsGroupedByAddresses:walletEx skipDenominated:skipDenominated anonymizable:anonymizable skipUnconfirmed:skipUnconfirmed maxOupointsPerAddress:maxOupointsPerAddress];
+    NSMutableSet<NSData *> *setWalletTxesCounted = [[NSMutableSet alloc] init];
+    
+    DSUTXO outpoint;
+    NSArray *utxos = self.chain.wallets.firstObject.unspentOutputs;
+    for (NSValue *value in utxos) {
+        [value getValue:&outpoint];
         
-        vecTallyRet = malloc(sizeof(SelectedCoins));
-        vecTallyRet->item_count = tempVecTallyRet.count;
-        vecTallyRet->items = malloc(tempVecTallyRet.count * sizeof(CompactTallyItem *));
-        
-        for (uint32_t i = 0; i < tempVecTallyRet.count; i++) {
-            vecTallyRet->items[i] = [tempVecTallyRet[i] ffi_malloc:wrapper.chain.chainType];
-        }
-    }
-    
-    return vecTallyRet;
-}
-
-void destroyInputValue(InputValue *value) {
-    DSLog(@"[OBJ-C] CoinJoin: 💀 InputValue");
-    
-    if (value) {
-        free(value);
-    }
-}
-
-void destroyTransaction(Transaction *value) {
-    if (value) {
-        [DSTransaction ffi_free:value];
-    }
-}
-
-void destroySelectedCoins(SelectedCoins *selectedCoins) {
-    if (!selectedCoins) {
-        return;
-    }
-    
-    DSLog(@"[OBJ-C] CoinJoin: 💀 SelectedCoins");
-    
-    if (selectedCoins->item_count > 0 && selectedCoins->items) {
-        for (int i = 0; i < selectedCoins->item_count; i++) {
-            [DSCompactTallyItem ffi_free:selectedCoins->items[i]];
+        if ([setWalletTxesCounted containsObject:uint256_data(outpoint.hash)]) {
+            continue;
         }
         
-        free(selectedCoins->items);
-    }
-    
-    free(selectedCoins);
-}
-
-void destroyGatheredOutputs(GatheredOutputs *gatheredOutputs) {
-    if (!gatheredOutputs) {
-        return;
-    }
-    
-    DSLog(@"[OBJ-C] CoinJoin: 💀 GatheredOutputs");
-    
-    if (gatheredOutputs->item_count > 0 && gatheredOutputs->items) {
-        for (int i = 0; i < gatheredOutputs->item_count; i++) {
-            [DSTransactionOutput ffi_free:gatheredOutputs->items[i]->output];
-            free(gatheredOutputs->items[i]->outpoint_hash);
+        [setWalletTxesCounted addObject:uint256_data(outpoint.hash)];
+        DSTransaction *wtx = [self.chain transactionForHash:outpoint.hash];
+        
+        if ([self isCoinJoinOutput:wtx.outputs[outpoint.n] utxo:outpoint]) {
+            
         }
-        
-        free(gatheredOutputs->items);
     }
-    
-    free(gatheredOutputs);
 }
 
-Transaction* signTransaction(Transaction *transaction, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: signTransaction");
+- (NSSet<DSTransaction *> *)getSpendableTXs {
+    NSMutableSet<DSTransaction *> *ret = [[NSMutableSet alloc] init];
+    NSArray *unspent = self.chain.wallets.firstObject.unspentOutputs;
     
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        DSTransaction *tx = [[DSTransaction alloc] initWithTransaction:transaction onChain:wrapper.chain];
-        destroy_transaction(transaction);
+    DSUTXO outpoint;
+    for (uint32_t i = 0; i < unspent.count; i++) {
+        [unspent[i] getValue:&outpoint];
+        DSTransaction *tx = [self.chain transactionForHash:outpoint.hash];
         
-        BOOL isSigned = [wrapper.chain.wallets.firstObject.accounts.firstObject signTransaction:tx];
-        
-        if (isSigned) {
-            return [tx ffi_malloc:wrapper.chain.chainType];
+        if (tx) {
+            [ret addObject:tx];
+            
+            // Skip entries until we encounter a new TX
+            DSUTXO nextOutpoint;
+            while (i + 1 < unspent.count) {
+                [unspent[i + 1] getValue:&nextOutpoint];
+                
+                if (!uint256_eq(nextOutpoint.hash, outpoint.hash)) {
+                    break;
+                }
+                i++;
+            }
         }
     }
     
-    return nil;
+    return ret;
 }
 
-unsigned int countInputsWithAmount(unsigned long long inputAmount, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: countInputsWithAmount");
-    return [AS_OBJC(context) countInputsWithAmount:inputAmount];
-}
-
-ByteArray freshCoinJoinAddress(bool internal, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: freshCoinJoinAddress");
-    DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-    NSString *address = [wrapper freshAddress:internal];
+- (NSString *)freshAddress:(BOOL)internal {
+    NSString *address;
+    DSAccount *account = self.chain.wallets.firstObject.accounts.firstObject;
     
-    return script_pubkey_for_address([address UTF8String], wrapper.chain.chainType);
-}
-
-bool commitTransaction(struct Recipient **items, uintptr_t item_count, const void *context) {
-    DSLog(@"[OBJ-C] CoinJoin: commitTransaction");
-    
-    NSMutableArray *amounts = [NSMutableArray array];
-    NSMutableArray *scripts = [NSMutableArray array];
-    
-    for (uintptr_t i = 0; i < item_count; i++) {
-        Recipient *recipient = items[i];
-        [amounts addObject:@(recipient->amount)];
-        NSData *script = [NSData dataWithBytes:recipient->script_pub_key.ptr length:recipient->script_pub_key.len];
-        [scripts addObject:script];
+    if (internal) {
+        address = account.coinJoinChangeAddress;
+        DSLog(@"[OBJ-C] CoinJoin: freshChangeAddress, address: %@", address);
+    } else {
+        address = account.coinJoinReceiveAddress;
+        DSLog(@"[OBJ-C] CoinJoin: freshReceiveAddress, address: %@", address);
     }
     
-    // TODO: check subtract_fee_from_amount
-    bool result = false;
+    return address;
+}
+
+- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs onPublished:(void (^)(NSError * _Nullable error))onPublished {
+    DSAccount *account = self.chain.wallets.firstObject.accounts.firstObject;
+    DSTransaction *transaction = [account transactionForAmounts:amounts toOutputScripts:outputs withFee:YES];
     
-    @synchronized (context) {
-        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        result = [wrapper commitTransactionForAmounts:amounts outputs:scripts onPublished:^(NSError * _Nullable error) {
-            if (!error) {
-                // TODO: let balance_denominated_unconf = balance_info.denominated_untrusted_pending;
-                uint64_t balanceDenominatedUnconf = 0;
-                DSLog(@"[OBJ-C] CoinJoin: call finish_automatic_denominating");
-                bool isFinished = finish_automatic_denominating(wrapper.manager.clientManager, balanceDenominatedUnconf, wrapper.balance_needs_anonymized);
-                DSLog(@"[OBJ-C] CoinJoin: is automatic_denominating finished: %s", isFinished ? "YES" : "NO");
+    if (!transaction) {
+        return NO;
+    }
+    
+    BOOL signedTransaction = [account signTransaction:transaction];
+    
+    if (!signedTransaction || !transaction.isSigned) {
+        DSLog(@"[OBJ-C] CoinJoin error: not signed");
+        return NO;
+    } else {
+        [self.chain.chainManager.transactionManager publishTransaction:transaction completion:^(NSError *error) {
+            if (error) {
+                DSLog(@"[OBJ-C] CoinJoin publish error: %@", error.description);
+                onPublished(error);
+            } else {
+                DSLog(@"[OBJ-C] CoinJoin publish success: %@", transaction.description);
+                onPublished(nil);
             }
         }];
     }
     
-    return result;
+    return YES;
 }
 
-MasternodeEntry* masternodeByHash(uint8_t (*hash)[32], const void *context) {
-    UInt256 mnHash = *((UInt256 *)hash);
-    MasternodeEntry *masternode;
-    
-    @synchronized (context) {
-        masternode = [[AS_OBJC(context) masternodeEntryByHash:mnHash] ffi_malloc];
-    }
-    
-    return masternode;
+- (DSSimplifiedMasternodeEntry *)masternodeEntryByHash:(UInt256)hash {
+    return [self.chainManager.masternodeManager.currentMasternodeList masternodeForRegistrationHash:hash];
 }
 
-void destroyMasternodeEntry(MasternodeEntry *masternodeEntry) {
-    if (!masternodeEntry) {
-        return;
-    }
-    
-    DSLog(@"[OBJ-C] CoinJoin: 💀 MasternodeEntry");
-    [DSSimplifiedMasternodeEntry ffi_free:masternodeEntry];
+- (uint64_t)validMNCount {
+    return self.chainManager.masternodeManager.currentMasternodeList.validMasternodeCount;
 }
 
-uint64_t validMNCount(const void *context) {
-    uint64_t result = 0;
-    
-    @synchronized (context) {
-        result = [AS_OBJC(context) validMNCount];
-    }
-    
-    return result;
+- (DSMasternodeList *)mnList {
+    return self.chainManager.masternodeManager.currentMasternodeList;
 }
 
-MasternodeList* getMNList(const void *context) {
-    MasternodeList *masternodes;
-    
-    @synchronized (context) {
-        masternodes = [[AS_OBJC(context) mnList] ffi_malloc];
-    }
-    
-    return masternodes;
+- (BOOL)isMasternodeOrDisconnectRequested {
+    return [_masternodeGroup isMasternodeOrDisconnectRequested];
 }
 
-void destroyMNList(MasternodeList *masternodeList) { // TODO: check destroyMasternodeList
-    if (!masternodeList) {
-        return;
-    }
-    
-    DSLog(@"[OBJ-C] CoinJoin: 💀 MasternodeList");
-    [DSMasternodeList ffi_free:masternodeList];
-}
-
-bool isBlockchainSynced(const void *context) {
-    BOOL result = NO;
-    
-    @synchronized (context) {
-        result = AS_OBJC(context).chainManager.combinedSyncProgress == 1.0;
-    }
-    
-    return result;
-}
-
-bool isMasternodeOrDisconnectRequested(uint8_t (*ip_address)[16], uint16_t port, const void *context) {
-    BOOL result = NO;
-    
-    @synchronized (context) {
-        // TODO: ip_address, port
-        result = AS_OBJC(context).isMasternodeOrDisconnectRequested;
-    }
-    
-    return result;
-}
-
-bool sendMessage(ByteArray *byteArray, uint8_t (*ip_address)[16], uint16_t port, const void *context) {
-    UInt128 ipAddress = *((UInt128 *)ip_address);
-    BOOL result = YES; // TODO
-    
-    @synchronized (context) {
-        NSData *message = [NSData dataWithBytes:byteArray->ptr length:byteArray->len];
-        [AS_OBJC(context) sendAcceptMessage:message withPeerIP:ipAddress port:port];
-    }
-    
-    return result;
+- (void)sendAcceptMessage:(NSData *)message withPeerIP:(UInt128)address port:(uint16_t)port {
+    DSCoinJoinAcceptMessage *request = [[DSCoinJoinAcceptMessage alloc] initWithData:message];
+    DSPeer *peer = [self.chainManager.peerManager peerForLocation:address port:port];
+    [peer sendRequest:request];
+//    [self.chainManager.peerManager sendRequest:request];
 }
 
 @end

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) DSChainManager *chainManager;
 @property (nonatomic, strong) DSChain *chain;
-@property (nonatomic, strong, nullable) DSCoinJoinManager *manager;
+@property (nonatomic, weak, nullable) DSCoinJoinManager *manager;
 @property (nonatomic, strong, nullable) DSMasternodeGroup *masternodeGroup;
 
 @property (nonatomic, assign, nullable) WalletEx *walletEx;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
@@ -16,39 +16,26 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "DSChain.h"
-#import "DSTransactionOutput.h"
-#import "DSCoinControl.h"
-#import "DSCompactTallyItem.h"
-#import "DSCoinJoinManager.h"
 #import "DSMasternodeGroup.h"
+#import "DSChainManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class DSCoinJoinManager;
+
 @interface DSCoinJoinWrapper : NSObject
 
-@property (nonatomic, assign, nullable) DSChainManager *chainManager;
-@property (nonatomic, strong, nullable) DSMasternodeGroup *masternodeGroup;
-@property (nonatomic, assign, nullable) CoinJoinClientOptions *options;
-@property (nonatomic, assign) uint64_t balance_needs_anonymized;
-@property (nonatomic, assign) BOOL anonymizableTallyCachedNonDenom;
-@property (nonatomic, assign) BOOL anonymizableTallyCached;
+@property (nonatomic, strong, nullable) DSChainManager *chainManager;
 @property (nonatomic, strong) DSChain *chain;
-@property (nonatomic, weak, nullable) DSCoinJoinManager *manager;
+@property (nonatomic, strong, nullable) DSCoinJoinManager *manager;
+@property (nonatomic, strong, nullable) DSMasternodeGroup *masternodeGroup;
 
-- (instancetype)initWithManagers:(DSChainManager *)chainManager coinJoinManager: (DSCoinJoinManager*)coinJoinMnager;
+@property (nonatomic, assign, nullable) WalletEx *walletEx;
+@property (nonatomic, assign, nullable) CoinJoinClientManager *clientManager;
+@property (nonatomic, assign, nullable) CoinJoinClientOptions *options;
 
-- (BOOL)isMineInput:(UInt256)txHash index:(uint32_t)index;
-- (NSArray<DSInputCoin *> *) availableCoins:(WalletEx *)walletEx onlySafe:(BOOL)onlySafe coinControl:(DSCoinControl *_Nullable)coinControl minimumAmount:(uint64_t)minimumAmount maximumAmount:(uint64_t)maximumAmount minimumSumAmount:(uint64_t)minimumSumAmount maximumCount:(uint64_t)maximumCount;
-- (NSArray<DSCompactTallyItem *> *)selectCoinsGroupedByAddresses:(WalletEx *)walletEx skipDenominated:(BOOL)skipDenominated anonymizable:(BOOL)anonymizable skipUnconfirmed:(BOOL)skipUnconfirmed maxOupointsPerAddress:(int32_t)maxOupointsPerAddress;
-- (uint32_t)countInputsWithAmount:(uint64_t)inputAmount;
-- (NSString *)freshAddress:(BOOL)internal;
-- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs onPublished:(void (^)(NSError * _Nullable error))onPublished;
-- (DSSimplifiedMasternodeEntry *)masternodeEntryByHash:(UInt256)hash;
-- (uint64_t)validMNCount;
-- (DSMasternodeList *)mnList;
-- (BOOL)isMasternodeOrDisconnectRequested;
-- (void)sendAcceptMessage:(NSData *)message withPeerIP:(UInt128)address port:(uint16_t)port;
+- (instancetype)initWithManagers:(DSCoinJoinManager *)manager chainManager:(DSChainManager *)chainManager;
+- (void)runCoinJoin;
 
 @end
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
On repeated runs of `do_automatic_denominating`, the balance passed from obj-c is wrong.

## What was done?
- Refactor `wrapper` and `manager` to switch them logically
- Recalculate balance info before running CoinJoin


## How Has This Been Tested?
N/A


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone