### PR TITLE
fix(coinjoin): sign collateral

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSTransaction+CoinJoin.m
+++ b/DashSync/shared/Models/CoinJoin/DSTransaction+CoinJoin.m
@@ -36,7 +36,15 @@
         UInt256 hashValue;
         memcpy(hashValue.u8, *input->input_hash, 32);
         NSNumber *index = @(input->index);
-        NSData *script = [NSData dataWithBytes:input->script length:input->script_length];
+        NSData *script;
+        
+        if (input->script && input->script_length != 0) {
+            script = [NSData dataWithBytes:input->script length:input->script_length];
+        } else {
+            DSTransaction *inputTx = [chain transactionForHash:hashValue];
+            script = [inputTx.outputs objectAtIndex:index.integerValue].outScript;
+        }
+        
         NSNumber *sequence = @(input->sequence);
         
         [hashes addObject:uint256_obj(hashValue)];


### PR DESCRIPTION
## Issue being fixed or feature implemented
`sign_collateral` fails because tx inputs don't have inScript.

## What was done?
- Get the actual inScript data if the input comes from Rust empty.


## How Has This Been Tested?
N/A


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone