### PR TITLE
feat: sending DSA to a connected masternode

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (DSMasternodeList *)mnList;
 - (BOOL)isMasternodeOrDisconnectRequested;
 - (void)sendAcceptMessage:(NSData *)message withPeerIP:(UInt128)address port:(uint16_t)port;
+- (void)connectToMasternodeWithIP:(UInt128)address port:(uint16_t)port;
 - (Balance *)getBalance;
 - (void)runCoinJoin;
 

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
@@ -246,7 +246,6 @@ int32_t const DEFAULT_MAX_DEPTH = 9999999;
             
             for (uint32_t i = 0; i < coin.outputs.count; i++) {
                 DSTransactionOutput *output = coin.outputs[i];
-//                DSLog(@"[OBJ-C] CoinJoin: check output: %llu", output.amount);
                 uint64_t value = output.amount;
                 BOOL found = NO;
                 
@@ -476,7 +475,7 @@ int32_t const DEFAULT_MAX_DEPTH = 9999999;
 
 - (void)sendAcceptMessage:(NSData *)message withPeerIP:(UInt128)address port:(uint16_t)port {
     DSCoinJoinAcceptMessage *request = [[DSCoinJoinAcceptMessage alloc] initWithData:message];
-    DSPeer *peer = [self.chainManager.peerManager peerForLocation:address port:port];
+    DSPeer *peer = [self.chainManager.peerManager connectedPeer]; // TODO: coinjoin peer management
     [peer sendRequest:request];
 }
 

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -367,7 +367,11 @@ MasternodeList* getMNList(const void *context) {
     MasternodeList *masternodes;
     
     @synchronized (context) {
-        masternodes = [[AS_OBJC(context).manager mnList] ffi_malloc];
+        DSCoinJoinWrapper *wrapper = AS_OBJC(context);
+        DSMasternodeList *mnList = [wrapper.manager mnList];
+        // TODO: might have 0 valid MNs, account for this
+        DSLog(@"[OBJ-C] CoinJoin: getMNList, valid count: %llu", mnList.validMasternodeCount);
+        masternodes = [mnList ffi_malloc];
     }
     
     return masternodes;

--- a/DashSync/shared/Models/Managers/Chain Managers/DSPeerManager.h
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSPeerManager.h
@@ -92,6 +92,8 @@ typedef NS_ENUM(uint16_t, DSDisconnectReason)
 
 - (void)sendRequest:(DSMessageRequest *)request;
 
+- (DSPeer *)connectedPeer; // TODO(coinjoin): temp
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DashSync/shared/Models/Managers/Chain Managers/DSPeerManager.m
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSPeerManager.m
@@ -169,6 +169,10 @@
     }
 }
 
+- (DSPeer *)connectedPeer { // TODO(coinjoin): temp
+    return self.connectedPeers.objectEnumerator.nextObject;
+}
+
 // MARK: - Managers
 
 - (DSMasternodeManager *)masternodeManager {


### PR DESCRIPTION
## Issue being fixed or feature implemented
- DSA message needs to be sent after `join_existing_queue` is called.

## What was done?
- Sending DSA to a connected masternode. This is just a "proof of concept" as later we'll have a DashJ's `MasternodeGroup` analog for handling conjoin connections.


## How Has This Been Tested?
NA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone