### PR TITLE
fix(coinjoin): derivation path crash

### DIFF
--- a/DashSync/shared/Models/Derivation Paths/DSFundsDerivationPath.m
+++ b/DashSync/shared/Models/Derivation Paths/DSFundsDerivationPath.m
@@ -140,6 +140,11 @@
 // following the last used address in the chain. The internal chain is used for change addresses and the external chain
 // for receive addresses.
 - (NSArray *)registerAddressesWithGapLimit:(NSUInteger)gapLimit internal:(BOOL)internal error:(NSError **)error {
+    if (![self hasExtendedPublicKey]) {
+        // Not initialized yet
+        return @[];
+    }
+    
     if (!self.account.wallet.isTransient) {
         NSAssert(self.addressesLoaded, @"addresses must be loaded before calling this function");
     }

--- a/DashSync/shared/Models/Managers/Service Managers/DSVersionManager.m
+++ b/DashSync/shared/Models/Managers/Service Managers/DSVersionManager.m
@@ -195,7 +195,13 @@
                                                                       authenticated = YES;
                                                                       @autoreleasepool {
                                                                           for (DSDerivationPath *derivationPath in derivationPaths) {
-                                                                              success &= !![derivationPath generateExtendedPublicKeyFromSeed:seed storeUnderWalletUniqueId:wallet.uniqueIDString];
+                                                                              OpaqueKey *key = [derivationPath generateExtendedPublicKeyFromSeed:seed storeUnderWalletUniqueId:wallet.uniqueIDString];
+                                                                              
+                                                                              if (key) {
+                                                                                  [derivationPath loadAddresses];
+                                                                              }
+                                                                              
+                                                                              success &= !!key;
                                                                           }
                                                                       }
                                                                       dispatch_semaphore_signal(sem);


### PR DESCRIPTION
## Issue being fixed or feature implemented
`registerAddressesWithGapLimit` call crashes on `NSAssert(self.addressesLoaded` in a newly added CoinJoin derivation path because the XPub hasn't been created yet and addresses aren't loaded

## What was done?
- Skip `registerAddressesWithGapLimit` if XPub isn't created
- Load addresses after `upgradeExtendedKeysForWallets` is done


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone