### PR TITLE
fix(coinjoin): derivation path crash

### DIFF
--- a/DashSync/shared/Models/Derivation Paths/DSFundsDerivationPath.m
+++ b/DashSync/shared/Models/Derivation Paths/DSFundsDerivationPath.m
@@ -140,9 +140,10 @@
 // following the last used address in the chain. The internal chain is used for change addresses and the external chain
 // for receive addresses.
 - (NSArray *)registerAddressesWithGapLimit:(NSUInteger)gapLimit internal:(BOOL)internal error:(NSError **)error {
-    if (!self.account.wallet.isTransient) {
-        NSAssert(self.addressesLoaded, @"addresses must be loaded before calling this function");
+    if (!self.account.wallet.isTransient && !self.addressesLoaded) {
+        return @[];
     }
+    
     @synchronized(self) {
         NSMutableArray *a = [NSMutableArray arrayWithArray:(internal) ? self.internalAddresses : self.externalAddresses];
         NSUInteger i = a.count;


### PR DESCRIPTION
## Issue being fixed or feature implemented
`registerAddressesWithGapLimit` call crashes on `NSAssert(self.addressesLoaded` in a newly added CoinJoin derivation path because the XPub hasn't been created yet and addresses aren't loaded

## What was done?
- Skip `registerAddressesWithGapLimit` if addresses aren't loaded


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone