### PR TITLE
fix(coinjoin): using coin_control to limit inputs for CJ transactions

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinControl.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinControl.h
@@ -16,6 +16,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "BigIntTypes.h"
 #import "dash_shared_core.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -40,11 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFFICoinControl:(CoinControl *)coinControl;
 
 - (BOOL)hasSelected;
-- (BOOL)isSelected:(NSValue *)output;
-- (void)select:(NSValue *)output;
-- (void)unSelect:(NSValue *)output;
-- (void)unSelectAll;
-- (void)useCoinJoin:(BOOL)fUseCoinJoin;
+- (BOOL)isSelected:(DSUTXO)utxo;
+- (void)useCoinJoin:(BOOL)useCoinJoin;
 - (BOOL)isUsingCoinJoin;
 
 @end

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)freshAddress:(BOOL)internal;
 - (NSArray<NSString *> *)getIssuedReceiveAddresses;
 - (NSArray<NSString *> *)getUsedReceiveAddresses;
-- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs onPublished:(void (^)(UInt256 txId, NSError * _Nullable error))onPublished;
+- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs coinControl:(DSCoinControl *)coinControl onPublished:(void (^)(UInt256 txId, NSError * _Nullable error))onPublished;
 - (DSSimplifiedMasternodeEntry *)masternodeEntryByHash:(UInt256)hash;
 - (uint64_t)validMNCount;
 - (DSMasternodeList *)mnList;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
@@ -488,9 +488,9 @@ static dispatch_once_t managerChainToken = 0;
                     continue;
                 }
                 
-                NSValue *outputValue = dsutxo_obj(((DSUTXO){wtxid, i}));
+                DSUTXO utxo = ((DSUTXO){wtxid, i});
                 
-                if (coinControl != nil && coinControl.hasSelected && !coinControl.allowOtherInputs && ![coinControl isSelected:outputValue]) {
+                if (coinControl != nil && coinControl.hasSelected && !coinControl.allowOtherInputs && ![coinControl isSelected:utxo]) {
                     continue;
                 }
                 
@@ -498,7 +498,7 @@ static dispatch_once_t managerChainToken = 0;
                     continue;
                 }
                 
-                if ([account isSpent:outputValue]) {
+                if ([account isSpent:dsutxo_obj(utxo)]) {
                     continue;
                 }
                 
@@ -563,7 +563,6 @@ static dispatch_once_t managerChainToken = 0;
         
         if (is_denominated_amount(output.amount)) {
             denominatedBalance += output.amount;
-            DSLog(@"[OBJ-C] CoinJoin: sum %llu (counting denominated %lu-th utxo of tx %@ amount %llu to %@)", denominatedBalance, outpoint.n, uint256_reverse_hex(tx.txHash), output.amount, output.address);
         }
     }
     
@@ -632,9 +631,9 @@ static dispatch_once_t managerChainToken = 0;
     return account.usedCoinJoinReceiveAddresses;
 }
 
-- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs onPublished:(void (^)(UInt256 txId, NSError * _Nullable error))onPublished {
+- (BOOL)commitTransactionForAmounts:(NSArray *)amounts outputs:(NSArray *)outputs coinControl:(DSCoinControl *)coinControl onPublished:(void (^)(UInt256 txId, NSError * _Nullable error))onPublished {
     DSAccount *account = self.chain.wallets.firstObject.accounts.firstObject;
-    DSTransaction *transaction = [account transactionForAmounts:amounts toOutputScripts:outputs withFee:YES];
+    DSTransaction *transaction = [account transactionForAmounts:amounts toOutputScripts:outputs withFee:YES coinControl:coinControl];
     
     if (!transaction) {
         return NO;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -233,13 +233,13 @@ bool isMineInput(uint8_t (*tx_hash)[32], uint32_t index, const void *context) {
     return result;
 }
 
-GatheredOutputs* availableCoins(bool onlySafe, CoinControl coinControl, WalletEx *walletEx, const void *context) {
+GatheredOutputs* availableCoins(bool onlySafe, CoinControl *coinControl, WalletEx *walletEx, const void *context) {
     GatheredOutputs *gatheredOutputs;
     
     @synchronized (context) {
         DSCoinJoinWrapper *wrapper = AS_OBJC(context);
         ChainType chainType = wrapper.chain.chainType;
-        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:&coinControl];
+        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:coinControl];
         NSArray<DSInputCoin *> *coins = [wrapper.manager availableCoins:walletEx onlySafe:onlySafe coinControl:cc minimumAmount:1 maximumAmount:MAX_MONEY minimumSumAmount:MAX_MONEY maximumCount:0];
         
         gatheredOutputs = malloc(sizeof(GatheredOutputs));
@@ -352,7 +352,7 @@ ByteArray freshCoinJoinAddress(bool internal, const void *context) {
     }
 }
 
-bool commitTransaction(struct Recipient **items, uintptr_t item_count, bool is_denominating, uint8_t (*client_session_id)[32], const void *context) {
+bool commitTransaction(struct Recipient **items, uintptr_t item_count, CoinControl *coinControl, bool is_denominating, uint8_t (*client_session_id)[32], const void *context) {
     DSLog(@"[OBJ-C] CoinJoin: commitTransaction");
     
     NSMutableArray *amounts = [NSMutableArray array];
@@ -369,7 +369,8 @@ bool commitTransaction(struct Recipient **items, uintptr_t item_count, bool is_d
     
     @synchronized (context) {
         DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        result = [wrapper.manager commitTransactionForAmounts:amounts outputs:scripts onPublished:^(UInt256 txId, NSError * _Nullable error) {
+        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:coinControl];
+        result = [wrapper.manager commitTransactionForAmounts:amounts outputs:scripts coinControl:cc onPublished:^(UInt256 txId, NSError * _Nullable error) {
             if (error) {
                 DSLog(@"[OBJ-C] CoinJoin: commit tx error: %@, tx type: %@", error, is_denominating ? @"denominations" : @"collateral");
             } else if (is_denominating) {

--- a/DashSync/shared/Models/Wallet/DSAccount.h
+++ b/DashSync/shared/Models/Wallet/DSAccount.h
@@ -26,6 +26,7 @@
 #import "DSFundsDerivationPath.h"
 #import "DSIncomingFundsDerivationPath.h"
 #import "DSTransaction.h"
+#import "DSCoinControl.h"
 #import "NSData+Dash.h"
 #import <CoreData/CoreData.h>
 #import <Foundation/Foundation.h>
@@ -176,6 +177,8 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 - (DSTransaction *_Nullable)transactionForAmounts:(NSArray *)amounts
                                   toOutputScripts:(NSArray *)scripts
                                           withFee:(BOOL)fee;
+
+- (DSTransaction *)transactionForAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee coinControl:(DSCoinControl *)coinControl;
 
 // returns an unsigned transaction that sends the specified amounts from the wallet to the specified output scripts
 - (DSTransaction *_Nullable)transactionForAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee toShapeshiftAddress:(NSString *_Nullable)shapeshiftAddress;

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -61,6 +61,7 @@
 #import "DSTransactionFactory.h"
 #import "DSTransactionInput.h"
 #import "DSTransactionOutput.h"
+#import "DSCoinControl.h"
 #import "NSData+Dash.h"
 #import "NSDate+Utils.h"
 #import "NSError+Dash.h"
@@ -182,7 +183,7 @@
 
 - (instancetype)initWithAccountNumber:(uint32_t)accountNumber withDerivationPaths:(NSArray<DSFundsDerivationPath *> *)derivationPaths inContext:(NSManagedObjectContext *)context {
     NSParameterAssert(derivationPaths);
-
+    
     if (!(self = [super init])) return nil;
     _accountNumber = accountNumber;
     [self verifyAndAssignAddedDerivationPaths:derivationPaths];
@@ -206,12 +207,12 @@
 
 - (instancetype)initAsViewOnlyWithAccountNumber:(uint32_t)accountNumber withDerivationPaths:(NSArray<DSFundsDerivationPath *> *)derivationPaths inContext:(NSManagedObjectContext *)context {
     NSParameterAssert(derivationPaths);
-
+    
     if (!(self = [self initWithAccountNumber:accountNumber withDerivationPaths:derivationPaths inContext:context])) return nil;
     self.isViewOnlyAccount = TRUE;
     self.transactionsToSave = [NSMutableArray array];
     self.transactionsToSaveInBlockSave = [NSMutableDictionary dictionary];
-
+    
     return self;
 }
 
@@ -236,17 +237,17 @@
             DSLogPrivate(@"[%@] Transaction %@", _wallet.chain.name, [transaction longDescription]);
         }
 #endif
-
+        
         NSUInteger transactionCount = [DSTransactionEntity countObjectsInContext:self.managedObjectContext matching:@"transactionHash.chain == %@", [self.wallet.chain chainEntityInContext:self.managedObjectContext]];
         if (transactionCount > self.allTx.count) {
             // pre-fetch transaction inputs and outputs
             @autoreleasepool {
                 NSFetchRequest *fetchRequest = [DSTxOutputEntity fetchRequest];
-
+                
                 //for some reason it is faster to search by the wallet unique id on the account, then it is by the account itself, this might change if there are more than 1 account;
                 fetchRequest.predicate = [NSPredicate predicateWithFormat:@"account.walletUniqueID = %@ && account.index = %@", self.wallet.uniqueIDString, @(self.accountNumber)];
                 [fetchRequest setRelationshipKeyPathsForPrefetching:@[@"transaction.inputs", @"transaction.outputs", @"transaction.transactionHash", @"spentInInput.transaction.inputs", @"spentInInput.transaction.outputs", @"spentInInput.transaction.transactionHash"]];
-
+                
                 NSError *fetchRequestError = nil;
                 //NSDate *transactionOutputsStartTime = [NSDate date];
                 NSArray *transactionOutputs = [self.managedObjectContext executeFetchRequest:fetchRequest error:&fetchRequestError];
@@ -331,7 +332,7 @@
 - (uint32_t)blockHeight {
     static uint32_t height = 0;
     uint32_t h = self.wallet.chain.lastSyncBlockHeight;
-
+    
     if (h > height) height = h;
     return height;
 }
@@ -377,7 +378,7 @@
 
 - (void)removeDerivationPath:(DSDerivationPath *)derivationPath {
     NSParameterAssert(derivationPath);
-
+    
     if ([self.mFundDerivationPaths containsObject:derivationPath]) {
         [self.mFundDerivationPaths removeObject:derivationPath];
     }
@@ -401,7 +402,7 @@
 
 - (void)addDerivationPath:(DSDerivationPath *)derivationPath {
     NSParameterAssert(derivationPath);
-
+    
     if (!_isViewOnlyAccount) {
         [self verifyAndAssignAddedDerivationPaths:@[derivationPath]];
     }
@@ -436,7 +437,7 @@
 
 - (void)addDerivationPathsFromArray:(NSArray<DSDerivationPath *> *)derivationPaths {
     NSParameterAssert(derivationPaths);
-
+    
     if (!_isViewOnlyAccount) {
         [self verifyAndAssignAddedDerivationPaths:derivationPaths];
     }
@@ -539,7 +540,7 @@
         //in case address is of type [NSNull null]
         return FALSE;
     }
-
+    
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         if ([derivationPath containsAddress:address]) return TRUE;
     }
@@ -553,7 +554,7 @@
         //in case address is of type [NSNull null]
         return FALSE;
     }
-
+    
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         if ([derivationPath isKindOfClass:[DSFundsDerivationPath class]] && [derivationPath containsChangeAddress:address]) {
             return TRUE;
@@ -568,7 +569,7 @@
         //in case address is of type [NSNull null]
         return FALSE;
     }
-
+    
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         if ([derivationPath isKindOfClass:[DSFundsDerivationPath class]] && [derivationPath containsAddress:address]) {
             return TRUE;
@@ -584,7 +585,7 @@
         //in case address is of type [NSNull null]
         return FALSE;
     }
-
+    
     for (DSDerivationPath *derivationPath in self.fundDerivationPaths) {
         if ([derivationPath isKindOfClass:[DSFundsDerivationPath class]]) {
             if ([(DSFundsDerivationPath *)derivationPath containsReceiveAddress:address]) return TRUE;
@@ -601,7 +602,7 @@
         //in case address is of type [NSNull null]
         return nil;
     }
-
+    
     for (DSIncomingFundsDerivationPath *derivationPath in self.mContactOutgoingFundDerivationPathsDictionary.allValues) {
         if ([derivationPath containsAddress:address]) return derivationPath;
     }
@@ -615,7 +616,7 @@
         //in case address is of type [NSNull null]
         return FALSE;
     }
-
+    
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         if ([derivationPath addressIsUsed:address]) return TRUE;
     }
@@ -628,11 +629,11 @@
         //in case address is of type [NSNull null]
         return FALSE;
     }
-
+    
     for (DSTransaction *transaction in self.allTransactions) {
         if ([transaction.outputs indexOfObjectPassingTest:^BOOL(DSTransactionOutput *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-                return [obj.address isEqual:address];
-            }] != NSNotFound) return TRUE;
+            return [obj.address isEqual:address];
+        }] != NSNotFound) return TRUE;
     }
     return FALSE;
 }
@@ -646,11 +647,11 @@
     NSMutableDictionary *pendingCoinbaseLockedTransactionHashes = [NSMutableDictionary dictionary];
     NSMutableArray *balanceHistory = [NSMutableArray array];
     uint32_t now = [NSDate timeIntervalSince1970];
-
+    
     for (DSFundsDerivationPath *derivationPath in self.fundDerivationPaths) {
         derivationPath.balance = 0;
     }
-
+    
     for (DSTransaction *tx in [self.transactions reverseObjectEnumerator]) {
 #if LOG_BALANCE_UPDATE
         DSLogPrivate(@"updating balance after transaction %@", [NSData dataWithUInt256:tx.txHash].reverse.hexString);
@@ -660,7 +661,7 @@
             NSSet *inputs;
             uint32_t n = 0;
             BOOL pending = NO;
-
+            
             if (!tx.isCoinbaseClassicTransaction &&
                 ![tx isKindOfClass:[DSCoinbaseTransaction class]]) {
                 NSMutableArray *rHashes = [NSMutableArray array];
@@ -680,19 +681,19 @@
             } else {
                 inputs = [NSSet set];
             }
-
+            
             [spentOutputs unionSet:spent]; // add inputs to spent output set
             n = 0;
-
+            
             // check if any inputs are pending
             if (tx.blockHeight == TX_UNCONFIRMED) {
                 if (tx.size > TX_MAX_SIZE) {
                     pending = YES; // check transaction size is under TX_MAX_SIZE
                 }
-
+                
                 for (DSTransactionInput *input in tx.inputs) {
                     if (input.sequence == UINT32_MAX) continue;
-
+                    
                     if (tx.lockTime < TX_MAX_LOCK_HEIGHT &&
                         tx.lockTime > self.wallet.chain.bestBlockHeight + 1) {
                         pending = YES; // future lockTime
@@ -712,7 +713,7 @@
 #endif
                     }
                 }
-
+                
                 for (DSTransactionOutput *output in tx.outputs) { // check that no outputs are dust
                     if (output.amount < TX_MIN_OUTPUT_AMOUNT) {
                         pending = YES;
@@ -724,15 +725,15 @@
                     }
                 }
             }
-
+            
             if (pending || [inputs intersectsSet:pendingTransactionHashes]) {
                 [pendingTransactionHashes addObject:uint256_obj(tx.txHash)];
                 [balanceHistory insertObject:@(balance) atIndex:0];
                 continue;
             }
-
+            
             uint32_t lockedBlockHeight = [self transactionOutputsAreLockedTill:tx];
-
+            
             if (lockedBlockHeight) {
                 if (![pendingCoinbaseLockedTransactionHashes objectForKey:@(lockedBlockHeight)]) {
                     pendingCoinbaseLockedTransactionHashes[@(lockedBlockHeight)] = [NSMutableSet set];
@@ -741,7 +742,7 @@
                 [balanceHistory insertObject:@(balance) atIndex:0];
                 continue;
             }
-
+            
             //TODO: don't add outputs below TX_MIN_OUTPUT_AMOUNT
             //TODO: don't add coin generation outputs < 100 blocks deep
             //NOTE: balance/UTXOs will then need to be recalculated when last block changes
@@ -759,15 +760,15 @@
                 }
                 n++;
             }
-
+            
             // transaction ordering is not guaranteed, so check the entire UTXO set against the entire spent output set
             [spent setSet:utxos.set];
             [spent intersectSet:spentOutputs];
-
+            
             for (NSValue *output in spent) { // remove any spent outputs from UTXO set
                 DSTransaction *transaction;
                 DSUTXO o;
-
+                
                 [output getValue:&o];
                 transaction = self.allTx[uint256_obj(o.hash)];
                 [utxos removeObject:output];
@@ -781,7 +782,7 @@
                     }
                 }
             }
-
+            
             if (prevBalance < balance) totalReceived += balance - prevBalance;
             if (balance < prevBalance) totalSent += prevBalance - balance;
             [balanceHistory insertObject:@(balance) atIndex:0];
@@ -802,7 +803,7 @@
 #endif
         }
     }
-
+    
     self.invalidTransactionHashes = invalidTx;
     self.pendingTransactionHashes = pendingTransactionHashes;
     self.pendingCoinbaseLockedTransactionHashes = pendingCoinbaseLockedTransactionHashes;
@@ -811,10 +812,10 @@
     self.balanceHistory = balanceHistory;
     _totalSent = totalSent;
     _totalReceived = totalReceived;
-
+    
     if (balance != _balance) {
         _balance = balance;
-
+        
         dispatch_async(dispatch_get_main_queue(), ^{
             [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(postBalanceDidChangeNotification) object:nil];
             [self performSelector:@selector(postBalanceDidChangeNotification) withObject:nil afterDelay:0.1];
@@ -825,9 +826,9 @@
 // historical wallet balance after the given transaction, or current balance if transaction is not registered in wallet
 - (uint64_t)balanceAfterTransaction:(DSTransaction *)transaction {
     NSParameterAssert(transaction);
-
+    
     NSUInteger i = [self.transactions indexOfObject:transaction];
-
+    
     return (i < self.balanceHistory.count) ? [self.balanceHistory[i] unsignedLongLongValue] : self.balance;
 }
 
@@ -846,7 +847,7 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
         NSUInteger i = [addressChain indexOfObject:output.address];
         if (i != NSNotFound) return i;
     }
-
+    
     return NSNotFound;
 }
 
@@ -861,11 +862,11 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
             if (tx1.blockHeight < tx2.blockHeight) return NO;
             NSValue *hash1 = uint256_obj(tx1.txHash), *hash2 = uint256_obj(tx2.txHash);
             if ([tx1.inputs indexOfObjectPassingTest:^BOOL(DSTransactionInput *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-                    return uint256_eq(obj.inputHash, tx2.txHash);
-                }] != NSNotFound) return YES;
+                return uint256_eq(obj.inputHash, tx2.txHash);
+            }] != NSNotFound) return YES;
             if ([tx2.inputs indexOfObjectPassingTest:^BOOL(DSTransactionInput *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-                    return uint256_eq(obj.inputHash, tx1.txHash);
-                }] != NSNotFound) return NO;
+                return uint256_eq(obj.inputHash, tx1.txHash);
+            }] != NSNotFound) return NO;
             if ([self.invalidTransactionHashes containsObject:hash1] && ![self.invalidTransactionHashes containsObject:hash2]) return YES;
             if ([self.pendingTransactionHashes containsObject:hash1] && ![self.pendingTransactionHashes containsObject:hash2]) return YES;
             for (DSTransactionInput *input in tx1.inputs) {
@@ -873,19 +874,19 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
             }
             return NO;
         };
-
+        
         [self.transactions sortWithOptions:NSSortStable
                            usingComparator:^NSComparisonResult(id tx1, id tx2) {
-                               if (isAscending(tx1, tx2)) return NSOrderedAscending;
-                               if (isAscending(tx2, tx1)) return NSOrderedDescending;
-
-                               NSUInteger i = transactionAddressIndex(tx1, self.internalAddresses);
-                               NSUInteger j = transactionAddressIndex(tx2, (i == NSNotFound) ? self.externalAddresses : self.internalAddresses);
-
-                               if (i == NSNotFound && j != NSNotFound) i = transactionAddressIndex(tx1, self.externalAddresses);
-                               if (i == NSNotFound || j == NSNotFound || i == j) return NSOrderedSame;
-                               return (i > j) ? NSOrderedAscending : NSOrderedDescending;
-                           }];
+            if (isAscending(tx1, tx2)) return NSOrderedAscending;
+            if (isAscending(tx2, tx1)) return NSOrderedDescending;
+            
+            NSUInteger i = transactionAddressIndex(tx1, self.internalAddresses);
+            NSUInteger j = transactionAddressIndex(tx2, (i == NSNotFound) ? self.externalAddresses : self.internalAddresses);
+            
+            if (i == NSNotFound && j != NSNotFound) i = transactionAddressIndex(tx1, self.externalAddresses);
+            if (i == NSNotFound || j == NSNotFound || i == j) return NSOrderedSame;
+            return (i > j) ? NSOrderedAscending : NSOrderedDescending;
+        }];
     }
 }
 
@@ -903,7 +904,7 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
 // last 100 transactions sorted by date, most recent first
 - (NSArray *)recentTransactions {
     return [self.transactions.array subarrayWithRange:NSMakeRange(0, (self.transactions.count > 100) ? 100 :
-                                                                                                       self.transactions.count)];
+                                                                  self.transactions.count)];
 }
 
 // last 100 transactions sorted by date, most recent first
@@ -971,14 +972,14 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
             DSProviderUpdateRegistrarTransaction *providerUpdateRegistrarTransaction = (DSProviderUpdateRegistrarTransaction *)transaction;
             if ([self containsAddress:providerUpdateRegistrarTransaction.payoutAddress]) return YES;
         }
-
+        
         return NO;
     }
 }
 
 - (BOOL)checkIsFirstTransaction:(DSTransaction *)transaction {
     NSParameterAssert(transaction);
-
+    
     for (DSDerivationPath *derivationPath in self.fundDerivationPaths) {
         if ([derivationPath type] & DSDerivationPathType_IsForFunds) {
             NSString *firstAddress;
@@ -988,8 +989,8 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
                 firstAddress = [(DSIncomingFundsDerivationPath *)derivationPath addressAtIndex:0];
             }
             if ([transaction.outputs indexOfObjectPassingTest:^BOOL(DSTransactionOutput *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-                    return [obj.address isEqual:firstAddress];
-                }] != NSNotFound) {
+                return [obj.address isEqual:firstAddress];
+            }] != NSNotFound) {
                 return TRUE;
             }
         }
@@ -1009,11 +1010,11 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
 // returns an unsigned transaction that sends the specified amount from the wallet to the given address
 - (DSCreditFundingTransaction *)creditFundingTransactionFor:(uint64_t)amount to:(NSString *)address withFee:(BOOL)fee {
     NSParameterAssert(address);
-
+    
     NSMutableData *script = [NSMutableData data];
-
+    
     [script appendCreditBurnScriptPubKeyForAddress:address forChain:self.wallet.chain];
-
+    
     DSCreditFundingTransaction *transaction = [[DSCreditFundingTransaction alloc] initOnChain:self.wallet.chain];
     return (DSCreditFundingTransaction *)[self updateTransaction:transaction forAmounts:@[@(amount)] toOutputScripts:@[script] withFee:fee sortType:DSTransactionSortType_BIP69];
 }
@@ -1021,14 +1022,18 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
 
 // returns an unsigned transaction that sends the specified amounts from the wallet to the specified output scripts
 - (DSTransaction *)transactionForAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee {
-    return [self transactionForAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:nil];
+    return [self transactionForAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:nil coinControl:nil];
 }
 
-- (DSTransaction *)transactionForAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee toShapeshiftAddress:(NSString *)shapeshiftAddress {
+- (DSTransaction *)transactionForAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee coinControl:(DSCoinControl *)coinControl {
+    return [self transactionForAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:nil coinControl:coinControl];
+}
+
+- (DSTransaction *)transactionForAmounts:(NSArray *)amounts toOutputScripts:(NSArray *)scripts withFee:(BOOL)fee toShapeshiftAddress:(NSString *)shapeshiftAddress coinControl:(DSCoinControl *)coinControl {
     NSParameterAssert(amounts);
     NSParameterAssert(scripts);
     DSTransaction *transaction = [[DSTransaction alloc] initOnChain:self.wallet.chain];
-    return [self updateTransaction:transaction forAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:shapeshiftAddress sortType:DSTransactionSortType_BIP69];
+    return [self updateTransaction:transaction forAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:shapeshiftAddress sortType:DSTransactionSortType_BIP69 coinControl:coinControl];
 }
 
 // MARK: == Proposal Transaction Creation
@@ -1055,7 +1060,7 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
                      toOutputScripts:(NSArray *)scripts
                              withFee:(BOOL)fee
                             sortType:(DSTransactionSortType)sortType {
-    return [self updateTransaction:transaction forAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:nil sortType:sortType];
+    return [self updateTransaction:transaction forAmounts:amounts toOutputScripts:scripts withFee:fee toShapeshiftAddress:nil sortType:sortType coinControl:nil];
 }
 
 // returns an unsigned transaction that sends the specified amounts from the wallet to the specified output scripts
@@ -1064,7 +1069,8 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
                      toOutputScripts:(NSArray *)scripts
                              withFee:(BOOL)fee
                  toShapeshiftAddress:(NSString *)shapeshiftAddress
-                            sortType:(DSTransactionSortType)sortType {
+                            sortType:(DSTransactionSortType)sortType
+                         coinControl:(DSCoinControl *)coinControl {
     NSParameterAssert(transaction);
     NSParameterAssert(amounts);
     NSParameterAssert(scripts);
@@ -1085,6 +1091,8 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
         //      attacker double spending and requesting a refund
         for (NSValue *output in self.utxos) {
             [output getValue:&o];
+            
+            if (coinControl && ![coinControl isSelected:o]) continue;
             tx = self.allTx[uint256_obj(o.hash)];
             if ([self transactionOutputsAreLocked:tx]) continue;
             if (!tx) continue;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Inputs for CoinJoin transactions are taken from already-denominated inputs which is an error.


## What was done?
Leverage CoinControll to limit inputs while forming a transaction.
dash-shared-core: https://github.com/dashpay/dash-shared-core/pull/89


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone