### PR TITLE
fix(coinjoin): simplify MasternodeGroup

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinControl.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinControl.m
@@ -72,7 +72,7 @@
         DSUTXO selectedUTXO;
         [selectedValue getValue:&selectedUTXO];
         
-        if (uint256_eq(utxo.hash, selectedUTXO.hash) && utxo.n == selectedUTXO.n) {
+        if (dsutxo_eq(utxo, selectedUTXO)) {
             return YES;
         }
     }

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -112,8 +112,6 @@
 
 - (void)processDSQueueFrom:(DSPeer *)peer message:(NSData *)message {
     @synchronized (self) {
-        DSLog(@"[OBJ-C] CoinJoin: process DSQ from %@", peer.location);
-        
         ByteArray *array = malloc(sizeof(ByteArray));
         array->len = (uintptr_t)message.length;
         array->ptr = data_malloc(message);
@@ -414,8 +412,6 @@ void destroyGatheredOutputs(GatheredOutputs *gatheredOutputs) {
 }
 
 Transaction* signTransaction(Transaction *transaction, bool anyoneCanPay, const void *context) {
-    DSLog(@"[OBJ-C CALLBACK] CoinJoin: signTransaction");
-    
     @synchronized (context) {
         DSCoinJoinWrapper *wrapper = AS_OBJC(context);
         DSTransaction *tx = [[DSTransaction alloc] initWithTransaction:transaction onChain:wrapper.chain];

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -1549,6 +1549,10 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
 }
 
 - (BOOL)isSpent:(NSValue *)output {
+    if (!output) {
+        return false;
+    }
+    
     return [self.spentOutputs containsObject:output];
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
MasternodeGroup is largely ported from DashJ. This means it drags in some DashJ-specific stuff since it is based on general-purpose PeerGroup. Some issues prevent it from being connected to the right masternodes at the right time.

## What was done?
Simplify `MasternodeGroup` to only connect to the masternodes connected to an active session.

## How Has This Been Tested?
N/A


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone