### PR TITLE
fix: pod install for xcode 16

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -26,17 +26,21 @@ target 'NetworkInfo' do
 end
 
 post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        # fixes warnings about unsupported Deployment Target in Xcode 10
-        target.build_configurations.each do |config|
-            config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+  installer.pods_project.targets.each do |target|
+      # fixes warnings about unsupported Deployment Target in Xcode 10
+      target.build_configurations.each do |config|
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      end
+
+      # Ensure the GCC_WARN_INHIBIT_ALL_WARNINGS flag is removed for BoringSSL-GRPC and BoringSSL-GRPC-iOS
+      if ['BoringSSL-GRPC', 'BoringSSL-GRPC-iOS'].include? target.name
+        target.source_build_phase.files.each do |file|
+          if file.settings && file.settings['COMPILER_FLAGS']
+            flags = file.settings['COMPILER_FLAGS'].split
+            flags.reject! { |flag| flag == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }
+            file.settings['COMPILER_FLAGS'] = flags.join(' ')
+          end
         end
-        # Hide warnings for specific pods
-        if ["gRPC"].include? target.name
-            target.build_configurations.each do |config|
-                config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
-            end
-        end
+      end
     end
 end
-


### PR DESCRIPTION
## Issue being fixed or feature implemented
Since XCode version 16, build of Dashsync was failing with:
`clang: error: unsupported option '-G' for target 'arm64-apple-xxx` (depending on the destination)
This originated from the pod BoringSSL-GRPC.

The issue is already reported in https://github.com/grpc/grpc/issues/36888

## What was done?
The fix consists of removing all flags `GCC_WARN_INHIBIT_ALL_WARNINGS` when building and installing pod BoringSSL-GRPC.

## How Has This Been Tested?
locally

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone