### PR TITLE
fix: check network GH workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,6 @@ jobs:
           xcode-version: '15.4'
       - name: Rustup add targets
         run: rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
-      - name: Clear dependencies
-        working-directory: ./dashsync/Example
-        run: rm -rf Podfile.lock Pods/ *.xcworkspace
       - name: Build dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive
@@ -48,7 +48,10 @@ jobs:
           xcode-version: '15.4'
       - name: Rustup add targets
         run: rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
-      - name: Dependencies
+      - name: Clear dependencies
+        working-directory: ./dashsync/Example
+        run: rm -rf Podfile.lock Pods/ *.xcworkspace
+      - name: Build dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update --verbose
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,4 +60,4 @@ jobs:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild build -scheme "DashSync-Example" -workspace "DashSync.xcworkspace" -destination "platform=$platform,name=iPhone 13"
+          xcodebuild build -scheme "DashSync-Example" -workspace "DashSync.xcworkspace" -destination "platform=$platform,name=iPhone 13" -allowProvisioningUpdates

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
 name: Continuous Integration
-
 on:
   push:
     branches:
@@ -10,7 +9,6 @@ on:
     branches:
       - master
       - develop
-
 jobs:
   build:
     name: Build
@@ -51,10 +49,14 @@ jobs:
       - name: Build dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update --verbose
-      - name: Build
+      - name: Build for iOS Simulator (without code signing)
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild build -scheme "DashSync-Example" -workspace "DashSync.xcworkspace" -destination "platform=$platform,name=iPhone 13" -allowProvisioningUpdates
+          xcodebuild build \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive

--- a/.github/workflows/e2eTestsTestnet.yml
+++ b/.github/workflows/e2eTestsTestnet.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive

--- a/.github/workflows/e2eTestsTestnet.yml
+++ b/.github/workflows/e2eTestsTestnet.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build for testing (without code signing)
+      - name: Build for testing (with ad-hoc code signing)
         working-directory: ./dashsync/Example
         env:
           scheme: ${{ 'DashSync-Example' }}
@@ -58,7 +58,7 @@ jobs:
             -scheme "DashSync-Example" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=YES CODE_SIGNING_ALLOWED=YES
       - name: Test Syncing Chain
         working-directory: ./dashsync/Example
         env:
@@ -69,5 +69,4 @@ jobs:
             -scheme "DashSync-Example" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
-            -testPlan TestnetE2ETests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            -testPlan TestnetE2ETests

--- a/.github/workflows/e2eTestsTestnet.yml
+++ b/.github/workflows/e2eTestsTestnet.yml
@@ -48,17 +48,26 @@ jobs:
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build
+      - name: Build for testing (without code signing)
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild build-for-testing -scheme "DashSync-Example" -workspace "DashSync.xcworkspace" -destination "platform=$platform,name=iPhone 13"
+          xcodebuild build-for-testing \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Syncing Chain
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan TestnetE2ETests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan TestnetE2ETests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -44,9 +44,6 @@ jobs:
         run: cargo install cargo-lipo
       - name: Rustup add targets
         run: rustup target add x86_64-apple-darwin
-      - name: Clear dependencies
-        working-directory: ./dashsync/Example
-        run: rm -rf Podfile.lock Pods/ *.xcworkspace
       - name: Build Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -71,7 +71,9 @@ jobs:
         run: |
           ./NetworkInfo -outputDir ~/
       - name: Archive network ping results
-        uses: actions/upload-artifact@v3  # Updated from v2 to v3
+        uses: actions/upload-artifact@v4  # Updated to v4
         with:
           name: testnet-network-report
           path: ~/networkHealth.json
+          retention-days: 30
+          compression-level: 6  # Default, adjust as needed

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive
@@ -44,9 +44,6 @@ jobs:
         run: cargo install cargo-lipo
       - name: Rustup add targets
         run: rustup target add x86_64-apple-darwin
-      - name: Clear dependencies
-        working-directory: ./dashsync/Example
-        run: rm -rf Podfile.lock Pods/ *.xcworkspace
       - name: Build Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -44,6 +44,9 @@ jobs:
         run: cargo install cargo-lipo
       - name: Rustup add targets
         run: rustup target add x86_64-apple-darwin
+      - name: Clear dependencies
+        working-directory: ./dashsync/Example
+        run: rm -rf Podfile.lock Pods/ *.xcworkspace
       - name: Build Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -44,7 +44,10 @@ jobs:
         run: cargo install cargo-lipo
       - name: Rustup add targets
         run: rustup target add x86_64-apple-darwin
-      - name: Dependencies
+      - name: Clear dependencies
+        working-directory: ./dashsync/Example
+        run: rm -rf Podfile.lock Pods/ *.xcworkspace
+      - name: Build Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
       - name: Cache network info build

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           ./NetworkInfo -outputDir ~/
       - name: Archive network ping results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3  # Updated from v2 to v3
         with:
           name: testnet-network-report
           path: ~/networkHealth.json

--- a/.github/workflows/syncTestMainnet.yml
+++ b/.github/workflows/syncTestMainnet.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive

--- a/.github/workflows/syncTestTestnet.yml
+++ b/.github/workflows/syncTestTestnet.yml
@@ -29,7 +29,7 @@ jobs:
           git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
         working-directory: ./dashsync
       - name: Restore LFS cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: lfs-cache
         with:
           path: dashsync/.git/lfs
@@ -48,17 +48,26 @@ jobs:
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build
+      - name: Build for testing (without code signing)
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild build-for-testing -scheme "DashSync-Example" -workspace "DashSync.xcworkspace" -destination "platform=$platform,name=iPhone 13"
+          xcodebuild build-for-testing \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Syncing Chain
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan TestnetSyncTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan TestnetSyncTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,36 +19,44 @@ jobs:
       - name: Install automake
         run: |
           brew install automake
+
       - name: Checkout DashSync
         uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive
+
       - name: Create LFS file list
         run: |
           git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
         working-directory: ./dashsync
+
       - name: Restore LFS cache
         uses: actions/cache@v3
         id: lfs-cache
         with:
           path: dashsync/.git/lfs
           key: lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+
       - name: Git LFS Pull
         run: git lfs pull
         working-directory: ./dashsync
+
       - uses: actions/cache@v3
         with:
           path: ./dashsync/Example/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+
       - name: Rustup add targets
         run: rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build for testing (with "Sign to Run Locally" code signing)
+
+      - name: Build for testing (with manual code signing)
         working-directory: ./dashsync/Example
         env:
           scheme: 'DashSync-Example'
@@ -58,8 +66,9 @@ jobs:
             -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Crypto
         working-directory: ./dashsync/Example
         env:
@@ -71,8 +80,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan CryptoTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Derivations
         working-directory: ./dashsync/Example
         env:
@@ -84,8 +94,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan DerivationTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Libraries
         working-directory: ./dashsync/Example
         env:
@@ -97,8 +108,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LibraryTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Governance
         working-directory: ./dashsync/Example
         env:
@@ -110,8 +122,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan GovernanceTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Payments
         working-directory: ./dashsync/Example
         env:
@@ -123,8 +136,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PaymentTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Masternode Lists
         working-directory: ./dashsync/Example
         env:
@@ -136,8 +150,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan MasternodeListTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Wallet
         working-directory: ./dashsync/Example
         env:
@@ -149,8 +164,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan WalletTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Platform Transitions
         working-directory: ./dashsync/Example
         env:
@@ -162,8 +178,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PlatformTransitionTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Transactions
         working-directory: ./dashsync/Example
         env:
@@ -175,8 +192,9 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan TransactionTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"
+
       - name: Test Locks
         working-directory: ./dashsync/Example
         env:
@@ -188,5 +206,5 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LockTests \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Sign to Run Locally"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
             -scheme "DashSync-Example" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Crypto
         working-directory: ./dashsync/Example
         env:
@@ -70,7 +70,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan CryptoTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Derivations
         working-directory: ./dashsync/Example
         env:
@@ -82,7 +82,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan DerivationTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Libraries
         working-directory: ./dashsync/Example
         env:
@@ -94,7 +94,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LibraryTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Governance
         working-directory: ./dashsync/Example
         env:
@@ -106,7 +106,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan GovernanceTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Payments
         working-directory: ./dashsync/Example
         env:
@@ -118,7 +118,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PaymentTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Masternode Lists
         working-directory: ./dashsync/Example
         env:
@@ -130,7 +130,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan MasternodeListTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Wallet
         working-directory: ./dashsync/Example
         env:
@@ -142,7 +142,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan WalletTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Platform Transitions
         working-directory: ./dashsync/Example
         env:
@@ -154,7 +154,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PlatformTransitionTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Transactions
         working-directory: ./dashsync/Example
         env:
@@ -166,7 +166,7 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan TransactionTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic
       - name: Test Locks
         working-directory: ./dashsync/Example
         env:
@@ -178,4 +178,4 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LockTests \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
+            CODE_SIGN_STYLE=Automatic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           brew install automake
       - name: Checkout DashSync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dashsync
           submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,145 +48,145 @@ jobs:
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build for testing (with ad-hoc code signing)
+      - name: Build for testing (with "Sign to Run Locally" code signing)
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild build-for-testing \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Crypto
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan CryptoTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Derivations
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan DerivationTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Libraries
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LibraryTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Governance
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan GovernanceTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Payments
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PaymentTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Masternode Lists
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan MasternodeListTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Wallet
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan WalletTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Platform Transitions
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PlatformTransitionTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Transactions
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan TransactionTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"
       - name: Test Locks
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'DashSync-Example' }}
-          platform: ${{ 'iOS Simulator' }}
+          scheme: 'DashSync-Example'
+          platform: 'iOS Simulator'
         run: |
           xcodebuild test-without-building \
-            -scheme "DashSync-Example" \
+            -scheme "$scheme" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LockTests \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="-"
+            CODE_SIGN_IDENTITY="Sign to Run Locally"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,80 +48,134 @@ jobs:
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build
+      - name: Build for testing (without code signing)
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild build-for-testing -scheme "DashSync-Example" -workspace "DashSync.xcworkspace" -destination "platform=$platform,name=iPhone 13"
+          xcodebuild build-for-testing \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Crypto
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan CryptoTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan CryptoTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Derivations
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan DerivationTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan DerivationTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Libraries
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan LibraryTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan LibraryTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Governance
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan GovernanceTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan GovernanceTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Payments
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan PaymentTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan PaymentTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Masternode Lists
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan MasternodeListTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan MasternodeListTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Wallet
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan WalletTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan WalletTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Platform Transitions
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan PlatformTransitionTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan PlatformTransitionTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Transactions
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan TransactionTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan TransactionTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO
       - name: Test Locks
         working-directory: ./dashsync/Example
         env:
-          scheme: ${{ 'default' }}
+          scheme: ${{ 'DashSync-Example' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          xcodebuild test-without-building -scheme "DashSync-Example" -workspace "DashSync.xcworkspace"  -destination "platform=$platform,name=iPhone 13" -testPlan LockTests
+          xcodebuild test-without-building \
+            -scheme "DashSync-Example" \
+            -workspace "DashSync.xcworkspace" \
+            -destination "platform=$platform,name=iPhone 13" \
+            -testPlan LockTests \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Dependencies
         working-directory: ./dashsync/Example
         run: pod install --repo-update
-      - name: Build for testing (without code signing)
+      - name: Build for testing (with ad-hoc code signing)
         working-directory: ./dashsync/Example
         env:
           scheme: ${{ 'DashSync-Example' }}
@@ -58,7 +58,8 @@ jobs:
             -scheme "DashSync-Example" \
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Crypto
         working-directory: ./dashsync/Example
         env:
@@ -70,7 +71,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan CryptoTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Derivations
         working-directory: ./dashsync/Example
         env:
@@ -82,7 +84,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan DerivationTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Libraries
         working-directory: ./dashsync/Example
         env:
@@ -94,7 +97,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LibraryTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Governance
         working-directory: ./dashsync/Example
         env:
@@ -106,7 +110,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan GovernanceTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Payments
         working-directory: ./dashsync/Example
         env:
@@ -118,7 +123,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PaymentTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Masternode Lists
         working-directory: ./dashsync/Example
         env:
@@ -130,7 +136,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan MasternodeListTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Wallet
         working-directory: ./dashsync/Example
         env:
@@ -142,7 +149,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan WalletTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Platform Transitions
         working-directory: ./dashsync/Example
         env:
@@ -154,7 +162,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan PlatformTransitionTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Transactions
         working-directory: ./dashsync/Example
         env:
@@ -166,7 +175,8 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan TransactionTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"
       - name: Test Locks
         working-directory: ./dashsync/Example
         env:
@@ -178,4 +188,5 @@ jobs:
             -workspace "DashSync.xcworkspace" \
             -destination "platform=$platform,name=iPhone 13" \
             -testPlan LockTests \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_IDENTITY="-"

--- a/DashSync.podspec
+++ b/DashSync.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.ios.framework = 'UIKit'
   s.macos.framework = 'Cocoa'
   s.compiler_flags = '-Wno-comma'
-  s.dependency 'DashSharedCore', '0.4.16'
+  s.dependency 'DashSharedCore', '0.4.17'
   s.dependency 'CocoaLumberjack', '3.7.2'
   s.ios.dependency 'DWAlertController', '0.2.1'
   s.dependency 'DSDynamicOptions', '0.1.2'

--- a/DashSync.podspec
+++ b/DashSync.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.ios.framework = 'UIKit'
   s.macos.framework = 'Cocoa'
   s.compiler_flags = '-Wno-comma'
-  s.dependency 'DashSharedCore', '0.4.17'
+  s.dependency 'DashSharedCore', '0.4.18'
   s.dependency 'CocoaLumberjack', '3.7.2'
   s.ios.dependency 'DWAlertController', '0.2.1'
   s.dependency 'DSDynamicOptions', '0.1.2'

--- a/DashSync/shared/Models/Managers/Chain Managers/DSBackgroundManager.m
+++ b/DashSync/shared/Models/Managers/Chain Managers/DSBackgroundManager.m
@@ -86,7 +86,11 @@
 }
 
 - (BOOL)hasValidHeadersTask {
+#if TARGET_OS_IOS
     return self.terminalHeadersSaveTaskId != UIBackgroundTaskInvalid || [UIApplication sharedApplication].applicationState != UIApplicationStateBackground;
+#else
+    return FALSE;
+#endif
 }
 
 @end

--- a/Example/DashSync.xcodeproj/project.pbxproj
+++ b/Example/DashSync.xcodeproj/project.pbxproj
@@ -51,7 +51,8 @@
 		2AF8A95622847ACB00F8C72D /* TextViewFormCellModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95522847ACB00F8C72D /* TextViewFormCellModel.m */; };
 		2AF8A95A22847E5300F8C72D /* DSContactProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95922847E5200F8C72D /* DSContactProfileViewController.m */; };
 		2AF8A95D2284820F00F8C72D /* DSContactProfileAvatarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95C2284820F00F8C72D /* DSContactProfileAvatarView.m */; };
-		328A9569D5871E42CA5F9D57 /* libPods-DashSync_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C5041A303DA8005AF8D8C194 /* libPods-DashSync_Tests.a */; };
+		2F5E40C2D9889BA0A1050512 /* libPods-NetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A472C095454625CDB8C64A6 /* libPods-NetworkInfo.a */; };
+		4C20F7670B15BB3F4F7716A2 /* libPods-DashSync_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 263FED967C4FB152D8B4D783 /* libPods-DashSync_Tests.a */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -65,13 +66,12 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
-		7400A509F640A9FA1A4AFD1E /* libPods-NetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BD218D7500924A42F48A67 /* libPods-NetworkInfo.a */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		93099D7228E7275400160709 /* MNLIST_1746460.dat in Resources */ = {isa = PBXBuildFile; fileRef = 93099D7028E7275300160709 /* MNLIST_1746460.dat */; };
 		93099D7328E7275400160709 /* MNL_1746460_1746516.dat in Resources */ = {isa = PBXBuildFile; fileRef = 93099D7128E7275400160709 /* MNL_1746460_1746516.dat */; };
 		937619A526E22E360023BE64 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 937619A326E22DCD0023BE64 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		A826AD0C6E7D15144036CB3E /* libPods-DashSync-DashSync_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C8FE4F7E21F52E59ADB43E69 /* libPods-DashSync-DashSync_Example.a */; };
 		B8D9D66B2CB5A33300D289A9 /* libDashSync-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */; };
+		B9BF3E8F8236AD6E7E3A1B83 /* libPods-DashSync-DashSync_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0731CDBFEC5046743137CCB5 /* libPods-DashSync-DashSync_Example.a */; };
 		FB0955CC244BBDC400A93675 /* DSContactRelationshipInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0955CB244BBDC400A93675 /* DSContactRelationshipInfoViewController.m */; };
 		FB0F15A2210490C3000272E6 /* DSTransactionDetailTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0F15A1210490C3000272E6 /* DSTransactionDetailTableViewCell.m */; };
 		FB0F15A521049432000272E6 /* DSTransactionStatusTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0F15A421049432000272E6 /* DSTransactionStatusTableViewCell.m */; };
@@ -521,6 +521,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		038B8B25F7F40A2448FAB877 /* Pods-DashSync-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.debug.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		0390824C4EEB495E475CAB59 /* Pods-DashSync_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.release.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		0731CDBFEC5046743137CCB5 /* libPods-DashSync-DashSync_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync-DashSync_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		263FED967C4FB152D8B4D783 /* libPods-DashSync_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27552411E6D7D4041AC16526 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		2A1AC63A20F9012A00B3B79F /* FormSectionModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FormSectionModel.h; sourceTree = "<group>"; };
 		2A1AC63B20F9012A00B3B79F /* FormSectionModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FormSectionModel.m; sourceTree = "<group>"; };
@@ -551,6 +555,7 @@
 		2A3B3EAA20F893F4002962FB /* BaseFormCellModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseFormCellModel.h; sourceTree = "<group>"; };
 		2A3B3EAB20F893F4002962FB /* FormTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FormTableViewController.h; sourceTree = "<group>"; };
 		2A3B3EB220F893F4002962FB /* BaseFormCellModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BaseFormCellModel.m; sourceTree = "<group>"; };
+		2A472C095454625CDB8C64A6 /* libPods-NetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NetworkInfo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A5C601322BFC65E00C6003F /* ML_at_122088.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = ML_at_122088.dat; sourceTree = "<group>"; };
 		2A5C601522BFE0D000C6003F /* MNL_0_122064.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_0_122064.dat; sourceTree = "<group>"; };
 		2A5C601622BFE0D100C6003F /* MNL_122064_122088.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_122064_122088.dat; sourceTree = "<group>"; };
@@ -591,7 +596,7 @@
 		2AF8A95922847E5200F8C72D /* DSContactProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactProfileViewController.m; sourceTree = "<group>"; };
 		2AF8A95B2284820F00F8C72D /* DSContactProfileAvatarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSContactProfileAvatarView.h; sourceTree = "<group>"; };
 		2AF8A95C2284820F00F8C72D /* DSContactProfileAvatarView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactProfileAvatarView.m; sourceTree = "<group>"; };
-		5797F9A5E0D453E1AE6AD191 /* Pods-NetworkInfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.debug.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.debug.xcconfig"; sourceTree = "<group>"; };
+		465173F50F99156A403A8507 /* Pods-DashSync-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.release.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* DashSync_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DashSync_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -611,23 +616,18 @@
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		64A245673BBAE1DA7DAB4907 /* DashSync.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = DashSync.podspec; path = ../DashSync.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		65579A860882BE9A628B6FE7 /* Pods-DashSync-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.release.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		76D24CDDC18A984CA2631A04 /* Pods-NetworkInfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.release.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.release.xcconfig"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		93099D7028E7275300160709 /* MNLIST_1746460.dat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MNLIST_1746460.dat; sourceTree = "<group>"; };
 		93099D7128E7275400160709 /* MNL_1746460_1746516.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_1746460_1746516.dat; sourceTree = "<group>"; };
 		937619A326E22DCD0023BE64 /* BackgroundTasks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BackgroundTasks.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/BackgroundTasks.framework; sourceTree = DEVELOPER_DIR; };
-		95BFAE93B5BDC98E3FF7D339 /* Pods-DashSync_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.debug.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		B79C23546B08F6CBE27B009B /* Pods-DashSync_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.release.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		96A8ADA8763651727971BF11 /* Pods-NetworkInfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.debug.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.debug.xcconfig"; sourceTree = "<group>"; };
 		B8D9D6682CB5A11B00D289A9 /* libDashSync-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libDashSync-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libDashSync-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D9D66C2CB5A36600D289A9 /* DashSharedCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DashSharedCore.xcframework; path = "../../dash-shared-core/dash-spv-apple-bindings/DashSharedCore/framework/DashSharedCore.xcframework"; sourceTree = "<group>"; };
-		C5041A303DA8005AF8D8C194 /* libPods-DashSync_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C8FE4F7E21F52E59ADB43E69 /* libPods-DashSync-DashSync_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync-DashSync_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CB469E015A96AA6F4E3E28CB /* Pods-NetworkInfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.release.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.release.xcconfig"; sourceTree = "<group>"; };
-		CD6B1FC65F799AAD2D4AEC1A /* Pods-DashSync-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.debug.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		DE41D5AFF36EAC9F55D916DD /* Pods-DashSync_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.debug.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		E47ABFD6469F1FD556CDA6C7 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		E8BD218D7500924A42F48A67 /* libPods-NetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NetworkInfo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB0955CA244BBDC400A93675 /* DSContactRelationshipInfoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSContactRelationshipInfoViewController.h; sourceTree = "<group>"; };
 		FB0955CB244BBDC400A93675 /* DSContactRelationshipInfoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactRelationshipInfoViewController.m; sourceTree = "<group>"; };
 		FB0F15A0210490C3000272E6 /* DSTransactionDetailTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSTransactionDetailTableViewCell.h; sourceTree = "<group>"; };
@@ -1202,7 +1202,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				A826AD0C6E7D15144036CB3E /* libPods-DashSync-DashSync_Example.a in Frameworks */,
+				B9BF3E8F8236AD6E7E3A1B83 /* libPods-DashSync-DashSync_Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1214,7 +1214,7 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				328A9569D5871E42CA5F9D57 /* libPods-DashSync_Tests.a in Frameworks */,
+				4C20F7670B15BB3F4F7716A2 /* libPods-DashSync_Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1223,7 +1223,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8D9D66B2CB5A33300D289A9 /* libDashSync-macOS.a in Frameworks */,
-				7400A509F640A9FA1A4AFD1E /* libPods-NetworkInfo.a in Frameworks */,
+				2F5E40C2D9889BA0A1050512 /* libPods-NetworkInfo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1233,12 +1233,12 @@
 		15D149D9AD161D779756AC18 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				CD6B1FC65F799AAD2D4AEC1A /* Pods-DashSync-DashSync_Example.debug.xcconfig */,
-				65579A860882BE9A628B6FE7 /* Pods-DashSync-DashSync_Example.release.xcconfig */,
-				95BFAE93B5BDC98E3FF7D339 /* Pods-DashSync_Tests.debug.xcconfig */,
-				B79C23546B08F6CBE27B009B /* Pods-DashSync_Tests.release.xcconfig */,
-				5797F9A5E0D453E1AE6AD191 /* Pods-NetworkInfo.debug.xcconfig */,
-				CB469E015A96AA6F4E3E28CB /* Pods-NetworkInfo.release.xcconfig */,
+				038B8B25F7F40A2448FAB877 /* Pods-DashSync-DashSync_Example.debug.xcconfig */,
+				465173F50F99156A403A8507 /* Pods-DashSync-DashSync_Example.release.xcconfig */,
+				DE41D5AFF36EAC9F55D916DD /* Pods-DashSync_Tests.debug.xcconfig */,
+				0390824C4EEB495E475CAB59 /* Pods-DashSync_Tests.release.xcconfig */,
+				96A8ADA8763651727971BF11 /* Pods-NetworkInfo.debug.xcconfig */,
+				76D24CDDC18A984CA2631A04 /* Pods-NetworkInfo.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1401,9 +1401,9 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				C8FE4F7E21F52E59ADB43E69 /* libPods-DashSync-DashSync_Example.a */,
-				C5041A303DA8005AF8D8C194 /* libPods-DashSync_Tests.a */,
-				E8BD218D7500924A42F48A67 /* libPods-NetworkInfo.a */,
+				0731CDBFEC5046743137CCB5 /* libPods-DashSync-DashSync_Example.a */,
+				263FED967C4FB152D8B4D783 /* libPods-DashSync_Tests.a */,
+				2A472C095454625CDB8C64A6 /* libPods-NetworkInfo.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2337,12 +2337,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "DashSync_Example" */;
 			buildPhases = (
-				636CBC1607A7FD4D9970E0EA /* [CP] Check Pods Manifest.lock */,
+				06F30795E4BD00161F28E823 /* [CP] Check Pods Manifest.lock */,
 				FB5A0FA7219506140079CF42 /* ShellScript */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				6A93D030A59173C490ED4687 /* [CP] Copy Pods Resources */,
+				238DB649B9DCB3334DCF8BB0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2357,7 +2357,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "DashSync_Tests" */;
 			buildPhases = (
-				40F5766E7B3EC70AE9F83DBD /* [CP] Check Pods Manifest.lock */,
+				762E7136E691E8FDB4A47DCA /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
@@ -2376,11 +2376,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FB9C9EFE25B80DB40039880E /* Build configuration list for PBXNativeTarget "NetworkInfo" */;
 			buildPhases = (
-				6E2E127DC5DC7C920C279245 /* [CP] Check Pods Manifest.lock */,
+				B54592A9AB8366AE6B5E1C87 /* [CP] Check Pods Manifest.lock */,
 				FB9C9EF625B80DB40039880E /* Sources */,
 				FB9C9EF725B80DB40039880E /* Frameworks */,
 				FB9C9EF825B80DB40039880E /* CopyFiles */,
-				286FA0E8B0A7E6D3F8B6703C /* [CP] Copy Pods Resources */,
+				56E9C13DD3CDDA92D41DD66D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2764,51 +2764,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		286FA0E8B0A7E6D3F8B6703C /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/DashSync-macOS/DashSync.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf-macOS/Protobuf_Privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-macOS/gRPCCertificates.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DashSync.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Protobuf_Privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		40F5766E7B3EC70AE9F83DBD /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DashSync_Tests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		636CBC1607A7FD4D9970E0EA /* [CP] Check Pods Manifest.lock */ = {
+		06F30795E4BD00161F28E823 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2830,7 +2786,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6A93D030A59173C490ED4687 /* [CP] Copy Pods Resources */ = {
+		238DB649B9DCB3334DCF8BB0 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2852,7 +2808,51 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6E2E127DC5DC7C920C279245 /* [CP] Check Pods Manifest.lock */ = {
+		56E9C13DD3CDDA92D41DD66D /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/DashSync-macOS/DashSync.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf-macOS/Protobuf_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-macOS/gRPCCertificates.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DashSync.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Protobuf_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		762E7136E691E8FDB4A47DCA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DashSync_Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B54592A9AB8366AE6B5E1C87 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3231,7 +3231,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CD6B1FC65F799AAD2D4AEC1A /* Pods-DashSync-DashSync_Example.debug.xcconfig */;
+			baseConfigurationReference = 038B8B25F7F40A2448FAB877 /* Pods-DashSync-DashSync_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3291,7 +3291,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65579A860882BE9A628B6FE7 /* Pods-DashSync-DashSync_Example.release.xcconfig */;
+			baseConfigurationReference = 465173F50F99156A403A8507 /* Pods-DashSync-DashSync_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3351,7 +3351,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 95BFAE93B5BDC98E3FF7D339 /* Pods-DashSync_Tests.debug.xcconfig */;
+			baseConfigurationReference = DE41D5AFF36EAC9F55D916DD /* Pods-DashSync_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3373,7 +3373,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B79C23546B08F6CBE27B009B /* Pods-DashSync_Tests.release.xcconfig */;
+			baseConfigurationReference = 0390824C4EEB495E475CAB59 /* Pods-DashSync_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3391,7 +3391,7 @@
 		};
 		FB9C9EFF25B80DB40039880E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5797F9A5E0D453E1AE6AD191 /* Pods-NetworkInfo.debug.xcconfig */;
+			baseConfigurationReference = 96A8ADA8763651727971BF11 /* Pods-NetworkInfo.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3457,7 +3457,7 @@
 		};
 		FB9C9F0025B80DB40039880E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CB469E015A96AA6F4E3E28CB /* Pods-NetworkInfo.release.xcconfig */;
+			baseConfigurationReference = 76D24CDDC18A984CA2631A04 /* Pods-NetworkInfo.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/Example/DashSync.xcodeproj/project.pbxproj
+++ b/Example/DashSync.xcodeproj/project.pbxproj
@@ -51,7 +51,7 @@
 		2AF8A95622847ACB00F8C72D /* TextViewFormCellModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95522847ACB00F8C72D /* TextViewFormCellModel.m */; };
 		2AF8A95A22847E5300F8C72D /* DSContactProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95922847E5200F8C72D /* DSContactProfileViewController.m */; };
 		2AF8A95D2284820F00F8C72D /* DSContactProfileAvatarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95C2284820F00F8C72D /* DSContactProfileAvatarView.m */; };
-		404946170FF870F9FBA4B3C7 /* libPods-NetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6675EA01A2AC0589160069A4 /* libPods-NetworkInfo.a */; };
+		328A9569D5871E42CA5F9D57 /* libPods-DashSync_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C5041A303DA8005AF8D8C194 /* libPods-DashSync_Tests.a */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -65,12 +65,13 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
-		798A60FA627EC43C0AB39611 /* libPods-DashSync-DashSync_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 192956F40996DE819B9D64AC /* libPods-DashSync-DashSync_Example.a */; };
-		83CFCA70892A5DF9F64BA1AA /* libPods-DashSync_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 955D615511918752AF099181 /* libPods-DashSync_Tests.a */; };
+		7400A509F640A9FA1A4AFD1E /* libPods-NetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8BD218D7500924A42F48A67 /* libPods-NetworkInfo.a */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		93099D7228E7275400160709 /* MNLIST_1746460.dat in Resources */ = {isa = PBXBuildFile; fileRef = 93099D7028E7275300160709 /* MNLIST_1746460.dat */; };
 		93099D7328E7275400160709 /* MNL_1746460_1746516.dat in Resources */ = {isa = PBXBuildFile; fileRef = 93099D7128E7275400160709 /* MNL_1746460_1746516.dat */; };
 		937619A526E22E360023BE64 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 937619A326E22DCD0023BE64 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		A826AD0C6E7D15144036CB3E /* libPods-DashSync-DashSync_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C8FE4F7E21F52E59ADB43E69 /* libPods-DashSync-DashSync_Example.a */; };
+		B8D9D66B2CB5A33300D289A9 /* libDashSync-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */; };
 		FB0955CC244BBDC400A93675 /* DSContactRelationshipInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0955CB244BBDC400A93675 /* DSContactRelationshipInfoViewController.m */; };
 		FB0F15A2210490C3000272E6 /* DSTransactionDetailTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0F15A1210490C3000272E6 /* DSTransactionDetailTableViewCell.m */; };
 		FB0F15A521049432000272E6 /* DSTransactionStatusTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0F15A421049432000272E6 /* DSTransactionStatusTableViewCell.m */; };
@@ -520,8 +521,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		131B02E9F838D9B0B88342E6 /* Pods-NetworkInfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.release.xcconfig"; path = "Pods/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.release.xcconfig"; sourceTree = "<group>"; };
-		192956F40996DE819B9D64AC /* libPods-DashSync-DashSync_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync-DashSync_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27552411E6D7D4041AC16526 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		2A1AC63A20F9012A00B3B79F /* FormSectionModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FormSectionModel.h; sourceTree = "<group>"; };
 		2A1AC63B20F9012A00B3B79F /* FormSectionModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FormSectionModel.m; sourceTree = "<group>"; };
@@ -592,8 +591,7 @@
 		2AF8A95922847E5200F8C72D /* DSContactProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactProfileViewController.m; sourceTree = "<group>"; };
 		2AF8A95B2284820F00F8C72D /* DSContactProfileAvatarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSContactProfileAvatarView.h; sourceTree = "<group>"; };
 		2AF8A95C2284820F00F8C72D /* DSContactProfileAvatarView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactProfileAvatarView.m; sourceTree = "<group>"; };
-		2CB0B2B92A8EA70CAE7DC362 /* Pods-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-DashSync_Example/Pods-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
-		425B12FE369253E7F3A93D58 /* Pods-DashSync-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		5797F9A5E0D453E1AE6AD191 /* Pods-NetworkInfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.debug.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* DashSync_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DashSync_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -613,19 +611,23 @@
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		64A245673BBAE1DA7DAB4907 /* DashSync.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = DashSync.podspec; path = ../DashSync.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		6675EA01A2AC0589160069A4 /* libPods-NetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NetworkInfo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		65579A860882BE9A628B6FE7 /* Pods-DashSync-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.release.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		74FDA0D6BCD2D779E20B58FC /* Pods-DashSync-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		93099D7028E7275300160709 /* MNLIST_1746460.dat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MNLIST_1746460.dat; sourceTree = "<group>"; };
 		93099D7128E7275400160709 /* MNL_1746460_1746516.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_1746460_1746516.dat; sourceTree = "<group>"; };
 		937619A326E22DCD0023BE64 /* BackgroundTasks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BackgroundTasks.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/BackgroundTasks.framework; sourceTree = DEVELOPER_DIR; };
-		955D615511918752AF099181 /* libPods-DashSync_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		98472781BAD8800EFF391FA4 /* Pods-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DashSync_Example/Pods-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		C90A9AD2C32828341F0E6915 /* Pods-DashSync_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		D1B8FECBB1652E781A9E4620 /* Pods-NetworkInfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.debug.xcconfig"; sourceTree = "<group>"; };
-		DFA886AB709D97089A70E82A /* Pods-DashSync_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		95BFAE93B5BDC98E3FF7D339 /* Pods-DashSync_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.debug.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		B79C23546B08F6CBE27B009B /* Pods-DashSync_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.release.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		B8D9D6682CB5A11B00D289A9 /* libDashSync-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libDashSync-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libDashSync-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B8D9D66C2CB5A36600D289A9 /* DashSharedCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DashSharedCore.xcframework; path = "../../dash-shared-core/dash-spv-apple-bindings/DashSharedCore/framework/DashSharedCore.xcframework"; sourceTree = "<group>"; };
+		C5041A303DA8005AF8D8C194 /* libPods-DashSync_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8FE4F7E21F52E59ADB43E69 /* libPods-DashSync-DashSync_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync-DashSync_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB469E015A96AA6F4E3E28CB /* Pods-NetworkInfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.release.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.release.xcconfig"; sourceTree = "<group>"; };
+		CD6B1FC65F799AAD2D4AEC1A /* Pods-DashSync-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.debug.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		E47ABFD6469F1FD556CDA6C7 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		E8BD218D7500924A42F48A67 /* libPods-NetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NetworkInfo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB0955CA244BBDC400A93675 /* DSContactRelationshipInfoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSContactRelationshipInfoViewController.h; sourceTree = "<group>"; };
 		FB0955CB244BBDC400A93675 /* DSContactRelationshipInfoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactRelationshipInfoViewController.m; sourceTree = "<group>"; };
 		FB0F15A0210490C3000272E6 /* DSTransactionDetailTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSTransactionDetailTableViewCell.h; sourceTree = "<group>"; };
@@ -1200,7 +1202,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				798A60FA627EC43C0AB39611 /* libPods-DashSync-DashSync_Example.a in Frameworks */,
+				A826AD0C6E7D15144036CB3E /* libPods-DashSync-DashSync_Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1212,7 +1214,7 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				83CFCA70892A5DF9F64BA1AA /* libPods-DashSync_Tests.a in Frameworks */,
+				328A9569D5871E42CA5F9D57 /* libPods-DashSync_Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1220,13 +1222,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				404946170FF870F9FBA4B3C7 /* libPods-NetworkInfo.a in Frameworks */,
+				B8D9D66B2CB5A33300D289A9 /* libDashSync-macOS.a in Frameworks */,
+				7400A509F640A9FA1A4AFD1E /* libPods-NetworkInfo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		15D149D9AD161D779756AC18 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				CD6B1FC65F799AAD2D4AEC1A /* Pods-DashSync-DashSync_Example.debug.xcconfig */,
+				65579A860882BE9A628B6FE7 /* Pods-DashSync-DashSync_Example.release.xcconfig */,
+				95BFAE93B5BDC98E3FF7D339 /* Pods-DashSync_Tests.debug.xcconfig */,
+				B79C23546B08F6CBE27B009B /* Pods-DashSync_Tests.release.xcconfig */,
+				5797F9A5E0D453E1AE6AD191 /* Pods-NetworkInfo.debug.xcconfig */,
+				CB469E015A96AA6F4E3E28CB /* Pods-NetworkInfo.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		2A1B55BC2226B15A008FED65 /* Contacts */ = {
 			isa = PBXGroup;
 			children = (
@@ -1360,7 +1376,7 @@
 				FB974F3125AE7A2200A1DCE7 /* CI */,
 				FB974F5025AE8E7000A1DCE7 /* Docs */,
 				FB974F0F25AE595700A1DCE7 /* Linting */,
-				83DC6095687FDE098549FF30 /* Pods */,
+				15D149D9AD161D779756AC18 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1377,14 +1393,17 @@
 		6003F58C195388D20070C39A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B8D9D66C2CB5A36600D289A9 /* DashSharedCore.xcframework */,
+				B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */,
+				B8D9D6682CB5A11B00D289A9 /* libDashSync-macOS.a */,
 				937619A326E22DCD0023BE64 /* BackgroundTasks.framework */,
 				6003F58D195388D20070C39A /* Foundation.framework */,
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				955D615511918752AF099181 /* libPods-DashSync_Tests.a */,
-				6675EA01A2AC0589160069A4 /* libPods-NetworkInfo.a */,
-				192956F40996DE819B9D64AC /* libPods-DashSync-DashSync_Example.a */,
+				C8FE4F7E21F52E59ADB43E69 /* libPods-DashSync-DashSync_Example.a */,
+				C5041A303DA8005AF8D8C194 /* libPods-DashSync_Tests.a */,
+				E8BD218D7500924A42F48A67 /* libPods-NetworkInfo.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1468,21 +1487,6 @@
 				27552411E6D7D4041AC16526 /* LICENSE */,
 			);
 			name = "Podspec Metadata";
-			sourceTree = "<group>";
-		};
-		83DC6095687FDE098549FF30 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				98472781BAD8800EFF391FA4 /* Pods-DashSync_Example.debug.xcconfig */,
-				2CB0B2B92A8EA70CAE7DC362 /* Pods-DashSync_Example.release.xcconfig */,
-				C90A9AD2C32828341F0E6915 /* Pods-DashSync_Tests.debug.xcconfig */,
-				DFA886AB709D97089A70E82A /* Pods-DashSync_Tests.release.xcconfig */,
-				D1B8FECBB1652E781A9E4620 /* Pods-NetworkInfo.debug.xcconfig */,
-				131B02E9F838D9B0B88342E6 /* Pods-NetworkInfo.release.xcconfig */,
-				425B12FE369253E7F3A93D58 /* Pods-DashSync-DashSync_Example.debug.xcconfig */,
-				74FDA0D6BCD2D779E20B58FC /* Pods-DashSync-DashSync_Example.release.xcconfig */,
-			);
-			name = Pods;
 			sourceTree = "<group>";
 		};
 		FB0F15B421090405000272E6 /* Blockchain Identities */ = {
@@ -2333,12 +2337,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "DashSync_Example" */;
 			buildPhases = (
-				BA464DCB59BC59A2B2C9AAD7 /* [CP] Check Pods Manifest.lock */,
+				636CBC1607A7FD4D9970E0EA /* [CP] Check Pods Manifest.lock */,
 				FB5A0FA7219506140079CF42 /* ShellScript */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				F3524DD5332FD019D466B225 /* [CP] Copy Pods Resources */,
+				6A93D030A59173C490ED4687 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2353,7 +2357,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "DashSync_Tests" */;
 			buildPhases = (
-				1A450F2773F81BAA9F430A99 /* [CP] Check Pods Manifest.lock */,
+				40F5766E7B3EC70AE9F83DBD /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
@@ -2372,11 +2376,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FB9C9EFE25B80DB40039880E /* Build configuration list for PBXNativeTarget "NetworkInfo" */;
 			buildPhases = (
-				2B9966A4344269C863326096 /* [CP] Check Pods Manifest.lock */,
+				6E2E127DC5DC7C920C279245 /* [CP] Check Pods Manifest.lock */,
 				FB9C9EF625B80DB40039880E /* Sources */,
 				FB9C9EF725B80DB40039880E /* Frameworks */,
 				FB9C9EF825B80DB40039880E /* CopyFiles */,
-				2B57EF3BDD3D325283813C84 /* [CP] Copy Pods Resources */,
+				286FA0E8B0A7E6D3F8B6703C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2406,7 +2410,7 @@
 					};
 					FB9C9EF925B80DB40039880E = {
 						CreatedOnToolsVersion = 12.3;
-						DevelopmentTeam = 44RJ69WHFF;
+						DevelopmentTeam = VYNC8YJV73;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -2760,25 +2764,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1A450F2773F81BAA9F430A99 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DashSync_Tests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2B57EF3BDD3D325283813C84 /* [CP] Copy Pods Resources */ = {
+		286FA0E8B0A7E6D3F8B6703C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2800,7 +2786,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2B9966A4344269C863326096 /* [CP] Check Pods Manifest.lock */ = {
+		40F5766E7B3EC70AE9F83DBD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2815,23 +2801,27 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NetworkInfo-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-DashSync_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BA464DCB59BC59A2B2C9AAD7 /* [CP] Check Pods Manifest.lock */ = {
+		636CBC1607A7FD4D9970E0EA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			inputFileListPaths = (
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-DashSync-DashSync_Example-checkManifestLockResult.txt",
 			);
@@ -2840,7 +2830,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F3524DD5332FD019D466B225 /* [CP] Copy Pods Resources */ = {
+		6A93D030A59173C490ED4687 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2860,6 +2850,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6E2E127DC5DC7C920C279245 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NetworkInfo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FB5A0FA7219506140079CF42 /* ShellScript */ = {
@@ -3219,7 +3231,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 425B12FE369253E7F3A93D58 /* Pods-DashSync-DashSync_Example.debug.xcconfig */;
+			baseConfigurationReference = CD6B1FC65F799AAD2D4AEC1A /* Pods-DashSync-DashSync_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3279,7 +3291,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 74FDA0D6BCD2D779E20B58FC /* Pods-DashSync-DashSync_Example.release.xcconfig */;
+			baseConfigurationReference = 65579A860882BE9A628B6FE7 /* Pods-DashSync-DashSync_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3339,7 +3351,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C90A9AD2C32828341F0E6915 /* Pods-DashSync_Tests.debug.xcconfig */;
+			baseConfigurationReference = 95BFAE93B5BDC98E3FF7D339 /* Pods-DashSync_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3361,7 +3373,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFA886AB709D97089A70E82A /* Pods-DashSync_Tests.release.xcconfig */;
+			baseConfigurationReference = B79C23546B08F6CBE27B009B /* Pods-DashSync_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3379,7 +3391,7 @@
 		};
 		FB9C9EFF25B80DB40039880E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D1B8FECBB1652E781A9E4620 /* Pods-NetworkInfo.debug.xcconfig */;
+			baseConfigurationReference = 5797F9A5E0D453E1AE6AD191 /* Pods-NetworkInfo.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3390,13 +3402,53 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 44RJ69WHFF;
+				DEVELOPMENT_TEAM = VYNC8YJV73;
 				ENABLE_HARDENED_RUNTIME = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-l\"BoringSSL-GRPC-macOS\"",
+					"-l\"CocoaImageHashing-macOS\"",
+					"-l\"CocoaLumberjack-macOS\"",
+					"-l\"DAPI-GRPC-macOS\"",
+					"-l\"DSDynamicOptions-macOS\"",
+					"-l\"DashSync-macOS\"",
+					"-l\"Protobuf-macOS\"",
+					"-l\"SDWebImage-macOS\"",
+					"-l\"TinyCborObjc-macOS\"",
+					"-l\"abseil-macOS\"",
+					"-l\"bz2\"",
+					"-l\"c++\"",
+					"-l\"dash_shared_core_macos\"",
+					"-l\"gRPC-Core-macOS\"",
+					"-l\"gRPC-ProtoRPC-macOS\"",
+					"-l\"gRPC-RxLibrary-macOS\"",
+					"-l\"gRPC-macOS\"",
+					"-l\"resolv\"",
+					"-l\"sqlite3\"",
+					"-l\"tinycbor-macOS\"",
+					"-l\"z\"",
+					"-framework",
+					"\"BackgroundTasks\"",
+					"-framework",
+					"\"Cocoa\"",
+					"-framework",
+					"\"CoreData\"",
+					"-framework",
+					"\"Foundation\"",
+					"-framework",
+					"\"ImageIO\"",
+					"-framework",
+					"\"Security\"",
+					"-framework",
+					"\"SystemConfiguration\"",
+					"\"-ld_classic\"",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
@@ -3405,7 +3457,7 @@
 		};
 		FB9C9F0025B80DB40039880E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 131B02E9F838D9B0B88342E6 /* Pods-NetworkInfo.release.xcconfig */;
+			baseConfigurationReference = CB469E015A96AA6F4E3E28CB /* Pods-NetworkInfo.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3417,13 +3469,53 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 44RJ69WHFF;
+				DEVELOPMENT_TEAM = VYNC8YJV73;
 				ENABLE_HARDENED_RUNTIME = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-l\"BoringSSL-GRPC-macOS\"",
+					"-l\"CocoaImageHashing-macOS\"",
+					"-l\"CocoaLumberjack-macOS\"",
+					"-l\"DAPI-GRPC-macOS\"",
+					"-l\"DSDynamicOptions-macOS\"",
+					"-l\"DashSync-macOS\"",
+					"-l\"Protobuf-macOS\"",
+					"-l\"SDWebImage-macOS\"",
+					"-l\"TinyCborObjc-macOS\"",
+					"-l\"abseil-macOS\"",
+					"-l\"bz2\"",
+					"-l\"c++\"",
+					"-l\"dash_shared_core_macos\"",
+					"-l\"gRPC-Core-macOS\"",
+					"-l\"gRPC-ProtoRPC-macOS\"",
+					"-l\"gRPC-RxLibrary-macOS\"",
+					"-l\"gRPC-macOS\"",
+					"-l\"resolv\"",
+					"-l\"sqlite3\"",
+					"-l\"tinycbor-macOS\"",
+					"-l\"z\"",
+					"-framework",
+					"\"BackgroundTasks\"",
+					"-framework",
+					"\"Cocoa\"",
+					"-framework",
+					"\"CoreData\"",
+					"-framework",
+					"\"Foundation\"",
+					"-framework",
+					"\"ImageIO\"",
+					"-framework",
+					"\"Security\"",
+					"-framework",
+					"\"SystemConfiguration\"",
+					"\"-ld_classic\"",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;

--- a/Example/DashSync.xcodeproj/project.pbxproj
+++ b/Example/DashSync.xcodeproj/project.pbxproj
@@ -51,8 +51,7 @@
 		2AF8A95622847ACB00F8C72D /* TextViewFormCellModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95522847ACB00F8C72D /* TextViewFormCellModel.m */; };
 		2AF8A95A22847E5300F8C72D /* DSContactProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95922847E5200F8C72D /* DSContactProfileViewController.m */; };
 		2AF8A95D2284820F00F8C72D /* DSContactProfileAvatarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF8A95C2284820F00F8C72D /* DSContactProfileAvatarView.m */; };
-		2F5E40C2D9889BA0A1050512 /* libPods-NetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A472C095454625CDB8C64A6 /* libPods-NetworkInfo.a */; };
-		4C20F7670B15BB3F4F7716A2 /* libPods-DashSync_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 263FED967C4FB152D8B4D783 /* libPods-DashSync_Tests.a */; };
+		4BBAD0ED05B8F29532D1887E /* libPods-NetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FCDB05396B2E9593183904E8 /* libPods-NetworkInfo.a */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -65,13 +64,14 @@
 		6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
+		65F8D081B17C5F08E6BBF4A8 /* libPods-DashSync-DashSync_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F6B6FEB4981DE6989D82EB0 /* libPods-DashSync-DashSync_Example.a */; };
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		93099D7228E7275400160709 /* MNLIST_1746460.dat in Resources */ = {isa = PBXBuildFile; fileRef = 93099D7028E7275300160709 /* MNLIST_1746460.dat */; };
 		93099D7328E7275400160709 /* MNL_1746460_1746516.dat in Resources */ = {isa = PBXBuildFile; fileRef = 93099D7128E7275400160709 /* MNL_1746460_1746516.dat */; };
 		937619A526E22E360023BE64 /* BackgroundTasks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 937619A326E22DCD0023BE64 /* BackgroundTasks.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B8D9D66B2CB5A33300D289A9 /* libDashSync-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */; };
-		B9BF3E8F8236AD6E7E3A1B83 /* libPods-DashSync-DashSync_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0731CDBFEC5046743137CCB5 /* libPods-DashSync-DashSync_Example.a */; };
+		D233D44D64AE2AA230F44AA7 /* libPods-DashSync_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DE90F593715182564EB9A7E8 /* libPods-DashSync_Tests.a */; };
 		FB0955CC244BBDC400A93675 /* DSContactRelationshipInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0955CB244BBDC400A93675 /* DSContactRelationshipInfoViewController.m */; };
 		FB0F15A2210490C3000272E6 /* DSTransactionDetailTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0F15A1210490C3000272E6 /* DSTransactionDetailTableViewCell.m */; };
 		FB0F15A521049432000272E6 /* DSTransactionStatusTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0F15A421049432000272E6 /* DSTransactionStatusTableViewCell.m */; };
@@ -521,10 +521,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		038B8B25F7F40A2448FAB877 /* Pods-DashSync-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.debug.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		0390824C4EEB495E475CAB59 /* Pods-DashSync_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.release.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		0731CDBFEC5046743137CCB5 /* libPods-DashSync-DashSync_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync-DashSync_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		263FED967C4FB152D8B4D783 /* libPods-DashSync_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27552411E6D7D4041AC16526 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		2A1AC63A20F9012A00B3B79F /* FormSectionModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FormSectionModel.h; sourceTree = "<group>"; };
 		2A1AC63B20F9012A00B3B79F /* FormSectionModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FormSectionModel.m; sourceTree = "<group>"; };
@@ -555,7 +551,6 @@
 		2A3B3EAA20F893F4002962FB /* BaseFormCellModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseFormCellModel.h; sourceTree = "<group>"; };
 		2A3B3EAB20F893F4002962FB /* FormTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FormTableViewController.h; sourceTree = "<group>"; };
 		2A3B3EB220F893F4002962FB /* BaseFormCellModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BaseFormCellModel.m; sourceTree = "<group>"; };
-		2A472C095454625CDB8C64A6 /* libPods-NetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NetworkInfo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A5C601322BFC65E00C6003F /* ML_at_122088.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = ML_at_122088.dat; sourceTree = "<group>"; };
 		2A5C601522BFE0D000C6003F /* MNL_0_122064.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_0_122064.dat; sourceTree = "<group>"; };
 		2A5C601622BFE0D100C6003F /* MNL_122064_122088.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_122064_122088.dat; sourceTree = "<group>"; };
@@ -596,7 +591,8 @@
 		2AF8A95922847E5200F8C72D /* DSContactProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactProfileViewController.m; sourceTree = "<group>"; };
 		2AF8A95B2284820F00F8C72D /* DSContactProfileAvatarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSContactProfileAvatarView.h; sourceTree = "<group>"; };
 		2AF8A95C2284820F00F8C72D /* DSContactProfileAvatarView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactProfileAvatarView.m; sourceTree = "<group>"; };
-		465173F50F99156A403A8507 /* Pods-DashSync-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.release.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
+		3024E8DE0B1B84642E65E70D /* Pods-DashSync_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.debug.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		37CF4766B1F8739167BAFE02 /* Pods-NetworkInfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.debug.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* DashSync_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DashSync_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -615,18 +611,21 @@
 		6003F5B7195388D20070C39A /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
+		61730B1B3737895F96BE6A54 /* Pods-DashSync-DashSync_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.debug.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		64A245673BBAE1DA7DAB4907 /* DashSync.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = DashSync.podspec; path = ../DashSync.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		6F6B6FEB4981DE6989D82EB0 /* libPods-DashSync-DashSync_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync-DashSync_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		76D24CDDC18A984CA2631A04 /* Pods-NetworkInfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.release.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.release.xcconfig"; sourceTree = "<group>"; };
+		77374E9036662C743187A1DA /* Pods-DashSync_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.release.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		93099D7028E7275300160709 /* MNLIST_1746460.dat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MNLIST_1746460.dat; sourceTree = "<group>"; };
 		93099D7128E7275400160709 /* MNL_1746460_1746516.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = MNL_1746460_1746516.dat; sourceTree = "<group>"; };
 		937619A326E22DCD0023BE64 /* BackgroundTasks.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BackgroundTasks.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/BackgroundTasks.framework; sourceTree = DEVELOPER_DIR; };
-		96A8ADA8763651727971BF11 /* Pods-NetworkInfo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.debug.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.debug.xcconfig"; sourceTree = "<group>"; };
 		B8D9D6682CB5A11B00D289A9 /* libDashSync-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libDashSync-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D9D66A2CB5A33300D289A9 /* libDashSync-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libDashSync-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8D9D66C2CB5A36600D289A9 /* DashSharedCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DashSharedCore.xcframework; path = "../../dash-shared-core/dash-spv-apple-bindings/DashSharedCore/framework/DashSharedCore.xcframework"; sourceTree = "<group>"; };
-		DE41D5AFF36EAC9F55D916DD /* Pods-DashSync_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync_Tests.debug.xcconfig"; path = "Target Support Files/Pods-DashSync_Tests/Pods-DashSync_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		BD44FCB7175424B2BE7993BB /* Pods-DashSync-DashSync_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DashSync-DashSync_Example.release.xcconfig"; path = "Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example.release.xcconfig"; sourceTree = "<group>"; };
+		D97E3B2F9438560328BFE431 /* Pods-NetworkInfo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkInfo.release.xcconfig"; path = "Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo.release.xcconfig"; sourceTree = "<group>"; };
+		DE90F593715182564EB9A7E8 /* libPods-DashSync_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DashSync_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E47ABFD6469F1FD556CDA6C7 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		FB0955CA244BBDC400A93675 /* DSContactRelationshipInfoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSContactRelationshipInfoViewController.h; sourceTree = "<group>"; };
 		FB0955CB244BBDC400A93675 /* DSContactRelationshipInfoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSContactRelationshipInfoViewController.m; sourceTree = "<group>"; };
@@ -1192,6 +1191,7 @@
 		FBF31B6D2231C53900393301 /* DSSignPayloadViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSSignPayloadViewController.h; sourceTree = "<group>"; };
 		FBF31B6E2231C53900393301 /* DSSignPayloadViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSSignPayloadViewController.m; sourceTree = "<group>"; };
 		FBF31B7022328AA800393301 /* DSProviderTransactionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DSProviderTransactionsTests.m; sourceTree = "<group>"; };
+		FCDB05396B2E9593183904E8 /* libPods-NetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NetworkInfo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1202,7 +1202,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				B9BF3E8F8236AD6E7E3A1B83 /* libPods-DashSync-DashSync_Example.a in Frameworks */,
+				65F8D081B17C5F08E6BBF4A8 /* libPods-DashSync-DashSync_Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1214,7 +1214,7 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				4C20F7670B15BB3F4F7716A2 /* libPods-DashSync_Tests.a in Frameworks */,
+				D233D44D64AE2AA230F44AA7 /* libPods-DashSync_Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1223,7 +1223,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B8D9D66B2CB5A33300D289A9 /* libDashSync-macOS.a in Frameworks */,
-				2F5E40C2D9889BA0A1050512 /* libPods-NetworkInfo.a in Frameworks */,
+				4BBAD0ED05B8F29532D1887E /* libPods-NetworkInfo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1233,12 +1233,12 @@
 		15D149D9AD161D779756AC18 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				038B8B25F7F40A2448FAB877 /* Pods-DashSync-DashSync_Example.debug.xcconfig */,
-				465173F50F99156A403A8507 /* Pods-DashSync-DashSync_Example.release.xcconfig */,
-				DE41D5AFF36EAC9F55D916DD /* Pods-DashSync_Tests.debug.xcconfig */,
-				0390824C4EEB495E475CAB59 /* Pods-DashSync_Tests.release.xcconfig */,
-				96A8ADA8763651727971BF11 /* Pods-NetworkInfo.debug.xcconfig */,
-				76D24CDDC18A984CA2631A04 /* Pods-NetworkInfo.release.xcconfig */,
+				61730B1B3737895F96BE6A54 /* Pods-DashSync-DashSync_Example.debug.xcconfig */,
+				BD44FCB7175424B2BE7993BB /* Pods-DashSync-DashSync_Example.release.xcconfig */,
+				3024E8DE0B1B84642E65E70D /* Pods-DashSync_Tests.debug.xcconfig */,
+				77374E9036662C743187A1DA /* Pods-DashSync_Tests.release.xcconfig */,
+				37CF4766B1F8739167BAFE02 /* Pods-NetworkInfo.debug.xcconfig */,
+				D97E3B2F9438560328BFE431 /* Pods-NetworkInfo.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1401,9 +1401,9 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				0731CDBFEC5046743137CCB5 /* libPods-DashSync-DashSync_Example.a */,
-				263FED967C4FB152D8B4D783 /* libPods-DashSync_Tests.a */,
-				2A472C095454625CDB8C64A6 /* libPods-NetworkInfo.a */,
+				6F6B6FEB4981DE6989D82EB0 /* libPods-DashSync-DashSync_Example.a */,
+				DE90F593715182564EB9A7E8 /* libPods-DashSync_Tests.a */,
+				FCDB05396B2E9593183904E8 /* libPods-NetworkInfo.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2337,12 +2337,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "DashSync_Example" */;
 			buildPhases = (
-				06F30795E4BD00161F28E823 /* [CP] Check Pods Manifest.lock */,
+				E5F7123626737B797889229A /* [CP] Check Pods Manifest.lock */,
 				FB5A0FA7219506140079CF42 /* ShellScript */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				238DB649B9DCB3334DCF8BB0 /* [CP] Copy Pods Resources */,
+				CD1F79E08B3F4F0921F064A8 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2357,7 +2357,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "DashSync_Tests" */;
 			buildPhases = (
-				762E7136E691E8FDB4A47DCA /* [CP] Check Pods Manifest.lock */,
+				D4B84AE4F85D9FB04692A770 /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
@@ -2376,11 +2376,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FB9C9EFE25B80DB40039880E /* Build configuration list for PBXNativeTarget "NetworkInfo" */;
 			buildPhases = (
-				B54592A9AB8366AE6B5E1C87 /* [CP] Check Pods Manifest.lock */,
+				8CDF557444C449CF3402DD40 /* [CP] Check Pods Manifest.lock */,
 				FB9C9EF625B80DB40039880E /* Sources */,
 				FB9C9EF725B80DB40039880E /* Frameworks */,
 				FB9C9EF825B80DB40039880E /* CopyFiles */,
-				56E9C13DD3CDDA92D41DD66D /* [CP] Copy Pods Resources */,
+				544387655732F2E6FFDFAD9D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2402,10 +2402,11 @@
 				ORGANIZATIONNAME = "Dash Core Group";
 				TargetAttributes = {
 					6003F589195388D20070C39A = {
-						DevelopmentTeam = 44RJ69WHFF;
+						ProvisioningStyle = Manual;
 					};
 					6003F5AD195388D20070C39A = {
 						DevelopmentTeam = 44RJ69WHFF;
+						ProvisioningStyle = Manual;
 						TestTargetID = 6003F589195388D20070C39A;
 					};
 					FB9C9EF925B80DB40039880E = {
@@ -2764,51 +2765,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		06F30795E4BD00161F28E823 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DashSync-DashSync_Example-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		238DB649B9DCB3334DCF8BB0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/DashSync-iOS/DashSync.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf-iOS/Protobuf_Privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-iOS/gRPCCertificates.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DashSync.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Protobuf_Privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		56E9C13DD3CDDA92D41DD66D /* [CP] Copy Pods Resources */ = {
+		544387655732F2E6FFDFAD9D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2830,7 +2787,51 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NetworkInfo/Pods-NetworkInfo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		762E7136E691E8FDB4A47DCA /* [CP] Check Pods Manifest.lock */ = {
+		8CDF557444C449CF3402DD40 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NetworkInfo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CD1F79E08B3F4F0921F064A8 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/DashSync-iOS/DashSync.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf-iOS/Protobuf_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-iOS/gRPCCertificates.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DashSync.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Protobuf_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DashSync-DashSync_Example/Pods-DashSync-DashSync_Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D4B84AE4F85D9FB04692A770 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2852,7 +2853,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B54592A9AB8366AE6B5E1C87 /* [CP] Check Pods Manifest.lock */ = {
+		E5F7123626737B797889229A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2867,7 +2868,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NetworkInfo-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-DashSync-DashSync_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3231,10 +3232,12 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 038B8B25F7F40A2448FAB877 /* Pods-DashSync-DashSync_Example.debug.xcconfig */;
+			baseConfigurationReference = 61730B1B3737895F96BE6A54 /* Pods-DashSync-DashSync_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 44RJ69WHFF;
+				CODE_SIGN_IDENTITY = "Sign to Run Locally";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DashSync/DashSync-Prefix.pch";
@@ -3285,16 +3288,18 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 465173F50F99156A403A8507 /* Pods-DashSync-DashSync_Example.release.xcconfig */;
+			baseConfigurationReference = BD44FCB7175424B2BE7993BB /* Pods-DashSync-DashSync_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 44RJ69WHFF;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DashSync/DashSync-Prefix.pch";
@@ -3345,16 +3350,19 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DE41D5AFF36EAC9F55D916DD /* Pods-DashSync_Tests.debug.xcconfig */;
+			baseConfigurationReference = 3024E8DE0B1B84642E65E70D /* Pods-DashSync_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEVELOPMENT_TEAM = 44RJ69WHFF;
+				CODE_SIGN_IDENTITY = "Sign to Run Locally";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
@@ -3373,7 +3381,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0390824C4EEB495E475CAB59 /* Pods-DashSync_Tests.release.xcconfig */;
+			baseConfigurationReference = 77374E9036662C743187A1DA /* Pods-DashSync_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
@@ -3391,7 +3399,7 @@
 		};
 		FB9C9EFF25B80DB40039880E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 96A8ADA8763651727971BF11 /* Pods-NetworkInfo.debug.xcconfig */;
+			baseConfigurationReference = 37CF4766B1F8739167BAFE02 /* Pods-NetworkInfo.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -3457,7 +3465,7 @@
 		};
 		FB9C9F0025B80DB40039880E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 76D24CDDC18A984CA2631A04 /* Pods-NetworkInfo.release.xcconfig */;
+			baseConfigurationReference = D97E3B2F9438560328BFE431 /* Pods-NetworkInfo.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -25,17 +25,21 @@ target 'NetworkInfo' do
 end
 
 post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        # fixes warnings about unsupported Deployment Target in Xcode 10
-        target.build_configurations.each do |config|
-            config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+  installer.pods_project.targets.each do |target|
+      # fixes warnings about unsupported Deployment Target in Xcode 10
+      target.build_configurations.each do |config|
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      end
+
+      # Ensure the GCC_WARN_INHIBIT_ALL_WARNINGS flag is removed for BoringSSL-GRPC and BoringSSL-GRPC-iOS
+      if ['BoringSSL-GRPC', 'BoringSSL-GRPC-iOS'].include? target.name
+        target.source_build_phase.files.each do |file|
+          if file.settings && file.settings['COMPILER_FLAGS']
+            flags = file.settings['COMPILER_FLAGS'].split
+            flags.reject! { |flag| flag == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }
+            file.settings['COMPILER_FLAGS'] = flags.join(' ')
+          end
         end
-        # Hide warnings for specific pods
-        if ["gRPC"].include? target.name
-            target.build_configurations.each do |config|
-                config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
-            end
-        end
+      end
     end
 end
-

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,7 @@
 def common_pods
 #  pod 'DashSharedCore', :git => 'https://github.com/dashpay/dash-shared-core.git', :branch => 'fix/core-20-test-additional'
-#  pod 'DashSharedCore', :git => 'https://github.com/dashpay/dash-shared-core.git', :commit => 'e2dc943'
+  pod 'DashSharedCore', :git => 'https://github.com/dashpay/dash-shared-core.git', :commit => 'b424aa0b0f8289fca00508a50daefffbec2f98dc'
+#  pod 'DashSharedCore', :path => '../../dash-shared-core/'
   pod 'DashSync', :path => '../'
   pod 'SDWebImage', '5.14.3'
   pod 'CocoaImageHashing', :git => 'https://github.com/ameingast/cocoaimagehashing.git', :commit => 'ad01eee'
@@ -32,7 +33,7 @@ post_install do |installer|
       end
 
       # Ensure the GCC_WARN_INHIBIT_ALL_WARNINGS flag is removed for BoringSSL-GRPC and BoringSSL-GRPC-iOS
-      if ['BoringSSL-GRPC', 'BoringSSL-GRPC-iOS'].include? target.name
+      if ['BoringSSL-GRPC', 'BoringSSL-GRPC-iOS', 'BoringSSL-GRPC-macOS'].include? target.name
         target.source_build_phase.files.each do |file|
           if file.settings && file.settings['COMPILER_FLAGS']
             flags = file.settings['COMPILER_FLAGS'].split

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,6 @@
 def common_pods
 #  pod 'DashSharedCore', :git => 'https://github.com/dashpay/dash-shared-core.git', :branch => 'fix/core-20-test-additional'
-  pod 'DashSharedCore', :git => 'https://github.com/dashpay/dash-shared-core.git', :commit => 'b424aa0b0f8289fca00508a50daefffbec2f98dc'
+  pod 'DashSharedCore', :git => 'https://github.com/dashpay/dash-shared-core.git', :commit => '7dda9489a1d23221032e2b050c31a317a6e95631'
 #  pod 'DashSharedCore', :path => '../../dash-shared-core/'
   pod 'DashSync', :path => '../'
   pod 'SDWebImage', '5.14.3'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -586,11 +586,11 @@ PODS:
     - "!ProtoCompiler-gRPCPlugin (~> 1.0)"
     - DAPI-GRPC/Messages
     - gRPC-ProtoRPC
-  - DashSharedCore (0.4.16)
+  - DashSharedCore (0.4.18)
   - DashSync (0.1.0):
     - CocoaLumberjack (= 3.7.2)
     - DAPI-GRPC (= 0.22.0-dev.8)
-    - DashSharedCore (= 0.4.16)
+    - DashSharedCore (= 0.4.18)
     - DSDynamicOptions (= 0.1.2)
     - DWAlertController (= 0.2.1)
     - TinyCborObjc (= 0.4.6)
@@ -657,7 +657,7 @@ PODS:
   - gRPC/Interface-Legacy (1.49.0):
     - gRPC-RxLibrary/Interface (= 1.49.0)
   - KVO-MVVM (0.5.1)
-  - Protobuf (3.27.2)
+  - Protobuf (3.28.2)
   - SDWebImage (5.14.3):
     - SDWebImage/Core (= 5.14.3)
   - SDWebImage/Core (5.14.3)
@@ -667,6 +667,7 @@ PODS:
 
 DEPENDENCIES:
   - CocoaImageHashing (from `https://github.com/ameingast/cocoaimagehashing.git`, commit `ad01eee`)
+  - DashSharedCore (from `https://github.com/dashpay/dash-shared-core.git`, commit `7dda9489a1d23221032e2b050c31a317a6e95631`)
   - DashSync (from `../`)
   - KVO-MVVM (= 0.5.1)
   - SDWebImage (= 5.14.3)
@@ -679,7 +680,6 @@ SPEC REPOS:
     - BoringSSL-GRPC
     - CocoaLumberjack
     - DAPI-GRPC
-    - DashSharedCore
     - DSDynamicOptions
     - DWAlertController
     - gRPC
@@ -696,6 +696,9 @@ EXTERNAL SOURCES:
   CocoaImageHashing:
     :commit: ad01eee
     :git: https://github.com/ameingast/cocoaimagehashing.git
+  DashSharedCore:
+    :commit: 7dda9489a1d23221032e2b050c31a317a6e95631
+    :git: https://github.com/dashpay/dash-shared-core.git
   DashSync:
     :path: "../"
 
@@ -703,6 +706,9 @@ CHECKOUT OPTIONS:
   CocoaImageHashing:
     :commit: ad01eee
     :git: https://github.com/ameingast/cocoaimagehashing.git
+  DashSharedCore:
+    :commit: 7dda9489a1d23221032e2b050c31a317a6e95631
+    :git: https://github.com/dashpay/dash-shared-core.git
 
 SPEC CHECKSUMS:
   "!ProtoCompiler": e9c09244955a8565817aa59a4787b6bb849a63c6
@@ -712,8 +718,8 @@ SPEC CHECKSUMS:
   CocoaImageHashing: 8656031d0899abe6c1c415827de43e9798189c53
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   DAPI-GRPC: 138d62523bbfe7e88a39896f1053c0bc12390d9f
-  DashSharedCore: 81d3327cbea4103114b768eed4d36e742417b63b
-  DashSync: 5c4dea6e4ef83df33f23f85b7f2b97ef6843de87
+  DashSharedCore: 39b477a8cb43f01ffb1a3e18a3ecc0c2bf38481b
+  DashSync: fea23e18c188a4c79852d1c6816b33a8b9852414
   DSDynamicOptions: 347cc5d2c4e080eb3de6a86719ad3d861b82adfc
   DWAlertController: 5f4cd8adf90336331c054857f709f5f8d4b16a5b
   gRPC: 64f36d689b2ecd99c4351f74e6f91347cdc65d9f
@@ -721,11 +727,11 @@ SPEC CHECKSUMS:
   gRPC-ProtoRPC: 1c223e0f1732bb8d0b9e9e0ea60cc0fe995b8e2d
   gRPC-RxLibrary: 92327f150e11cf3b1c0f52e083944fd9f5cb5d1e
   KVO-MVVM: 4df3afd1f7ebcb69735458b85db59c4271ada7c6
-  Protobuf: fb2c13674723f76ff6eede14f78847a776455fa2
+  Protobuf: 28c89b24435762f60244e691544ed80f50d82701
   SDWebImage: 9c36e66c8ce4620b41a7407698dda44211a96764
   tinycbor: d4d71dddda1f8392fbb4249f63faf8552f327590
   TinyCborObjc: 5204540fb90ff0c40fb22d408fa51bab79d78a80
 
-PODFILE CHECKSUM: 8cb419eb95422ed65fbdc41960e405e8cc54dda7
+PODFILE CHECKSUM: 2b3437e89ea617e5578cf4e8071a4bb1cc5edd31
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
## Issue being fixed or feature implemented
Check Network flow was reporting `This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v2`

## What was done?
Bumped to upload-artifact: v4.

## How Has This Been Tested?



## Breaking Changes


## Checklist:


- [ ] I have assigned this pull request to a milestone