### PR TITLE
feat(coinjoin): cache transaction amount and direction

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isDenominatedAmount:(uint64_t)amount;
 - (BOOL)isFullyMixed:(DSUTXO)utxo;
 + (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction;
++ (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction account:(DSAccount *)account;
 - (uint64_t)getAnonymizableBalance:(BOOL)skipDenominated skipUnconfirmed:(BOOL)skipUnconfirmed;
 - (uint64_t)getSmallestDenomination;
 - (void)updateOptions:(CoinJoinClientOptions *)options;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -158,6 +158,10 @@
 
 + (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction {
     DSAccount *account = [transaction.chain firstAccountThatCanContainTransaction:transaction];
+    return [DSCoinJoinWrapper coinJoinTxTypeForTransaction:transaction account:account];
+}
+
++ (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction account:(DSAccount *)account {
     NSArray *amountsSent = [account amountsSentByTransaction:transaction];
     
     Transaction *tx = [transaction ffi_malloc:transaction.chain.chainType];

--- a/DashSync/shared/Models/CoinJoin/DSTransaction+CoinJoin.m
+++ b/DashSync/shared/Models/CoinJoin/DSTransaction+CoinJoin.m
@@ -65,7 +65,7 @@
         NSString *address = [DSKeyManager addressWithScriptPubKey:scriptPubKey forChain:chain];
         NSNumber *amount = @(output->amount);
         
-        [addresses addObject:address ?: [NSNull null]]; // Use NSNull for OP_RETURN or similar
+        [addresses addObject:address ?: [NSNull null]]; // Use NSNull turned into OP_RETURN script later
         [amounts addObject:amount];
     }
 

--- a/DashSync/shared/Models/Transactions/Base/DSTransaction.h
+++ b/DashSync/shared/Models/Transactions/Base/DSTransaction.h
@@ -90,7 +90,8 @@ typedef NS_ENUM(NSInteger, DSTransactionSortType)
 @property (nonatomic, assign) uint32_t lockTime;
 @property (nonatomic, assign) uint64_t feeUsed;
 @property (nonatomic, assign) uint64_t roundedFeeCostPerByte;
-@property (nonatomic, readonly) uint64_t amountSent;
+@property (nonatomic, readonly) DSTransactionDirection direction;
+@property (nonatomic, readonly) uint64_t dashAmount;
 @property (nonatomic, readonly) NSData *payloadData;
 @property (nonatomic, readonly) NSData *payloadDataForHash;
 @property (nonatomic, assign) uint32_t payloadOffset;
@@ -175,10 +176,6 @@ typedef NS_ENUM(NSInteger, DSTransactionSortType)
 
 - (int32_t)getBlocksToMaturity;
 
-@end
-
-@interface DSTransaction (Extensions)
-- (DSTransactionDirection)direction;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Issue being fixed or feature implemented
Calculating the amount and direction can take a long time, especially for CoinJoin transactions.

## What was done?
- Cache direction and amount
- Some synchronization fixes


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone