### PR TITLE
fix(coinjoin): add destination_change to coin control

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinControl.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinControl.h
@@ -37,8 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSNumber *confirmTarget;
 @property (nonatomic, assign) CoinType coinType;
 @property (nonatomic, strong) NSMutableOrderedSet *setSelected;
+@property (nonatomic, strong) NSString *destChange;
 
-- (instancetype)initWithFFICoinControl:(CoinControl *)coinControl;
+- (instancetype)initWithFFICoinControl:(CoinControl *)coinControl chainType:(ChainType)chainType;
 
 - (BOOL)hasSelected;
 - (BOOL)isSelected:(DSUTXO)utxo;

--- a/DashSync/shared/Models/CoinJoin/DSCoinControl.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinControl.m
@@ -19,13 +19,18 @@
 
 @implementation DSCoinControl
 
-- (instancetype)initWithFFICoinControl:(CoinControl *)coinControl {
+- (instancetype)initWithFFICoinControl:(CoinControl *)coinControl chainType:(ChainType)chainType {
     if (!(self = [super init])) return nil;
     self.coinType = coinControl->coin_type;
     self.minDepth = coinControl->min_depth;
     self.maxDepth = coinControl->max_depth;
     self.avoidAddressReuse = coinControl->avoid_address_reuse;
     self.allowOtherInputs = coinControl->allow_other_inputs;
+    
+    if (coinControl->dest_change) {
+        char *c_string = address_with_script_pubkey(coinControl->dest_change->ptr, coinControl->dest_change->len, chainType);
+        self.destChange = [NSString stringWithUTF8String:c_string];
+    }
 
     if (coinControl->set_selected && coinControl->set_selected_size > 0) {
         self.setSelected = [[NSMutableOrderedSet alloc] init];
@@ -59,6 +64,7 @@
         _avoidPartialSpends = NO;
         _avoidAddressReuse = NO;
         _minDepth = 0;
+        _destChange = NULL;
     }
     return self;
 }

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -347,7 +347,7 @@ GatheredOutputs* availableCoins(bool onlySafe, CoinControl *coinControl, WalletE
     @synchronized (context) {
         DSCoinJoinWrapper *wrapper = AS_OBJC(context);
         ChainType chainType = wrapper.chain.chainType;
-        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:coinControl];
+        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:coinControl chainType:wrapper.chain.chainType];
         NSArray<DSInputCoin *> *coins = [wrapper.manager availableCoins:walletEx onlySafe:onlySafe coinControl:cc minimumAmount:1 maximumAmount:MAX_MONEY minimumSumAmount:MAX_MONEY maximumCount:0];
         
         gatheredOutputs = malloc(sizeof(GatheredOutputs));
@@ -471,7 +471,7 @@ bool commitTransaction(struct Recipient **items, uintptr_t item_count, CoinContr
     
     @synchronized (context) {
         DSCoinJoinWrapper *wrapper = AS_OBJC(context);
-        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:coinControl];
+        DSCoinControl *cc = [[DSCoinControl alloc] initWithFFICoinControl:coinControl chainType:wrapper.chain.chainType];
         result = [wrapper.manager commitTransactionForAmounts:amounts outputs:scripts coinControl:cc onPublished:^(UInt256 txId, NSError * _Nullable error) {
             @synchronized (context) {
                 if (error) {

--- a/DashSync/shared/Models/Transactions/Base/DSTransaction.m
+++ b/DashSync/shared/Models/Transactions/Base/DSTransaction.m
@@ -327,7 +327,7 @@
     if (self.cachedDashAmount != UINT64_MAX) {
         return self.cachedDashAmount;
     }
-
+    
     uint64_t amount = 0;
     const uint64_t sent = [self.chain amountSentByTransaction:self];
     const uint64_t received = [self.chain amountReceivedFromTransaction:self];

--- a/DashSync/shared/Models/Wallet/DSAccount.m
+++ b/DashSync/shared/Models/Wallet/DSAccount.m
@@ -1192,9 +1192,18 @@ static NSUInteger transactionAddressIndex(DSTransaction *transaction, NSArray *a
         if (followBIP69sorting) {
             [transaction sortInputsAccordingToBIP69];
         }
-
+        
         if (balance - (amount + feeAmount) >= self.wallet.chain.minOutputAmount) {
-            [transaction addOutputAddress:self.changeAddress amount:balance - (amount + feeAmount)];
+            NSString *changeAddress;
+            
+            if (coinControl.destChange) {
+                changeAddress = coinControl.destChange;
+            } else {
+                changeAddress = self.changeAddress;
+            }
+            
+            [transaction addOutputAddress:changeAddress amount:balance - (amount + feeAmount)];
+            
             if (followBIP69sorting) {
                 [transaction sortOutputsAccordingToBIP69];
             } else if (sortType == DSTransactionSortType_Shuffle) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
CoinControl doesn't account for the `destination_change` parameter which can lead the change to be returned to a wrong address.

## What was done?
- Implemented `destination_change`
dash-shared-core: https://github.com/dashpay/dash-shared-core/pull/102

## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone