### PR TITLE
fix: memory & lock issues in sortTransactions

### DIFF
--- a/DashSync/shared/Models/Wallet/DSAccount.h
+++ b/DashSync/shared/Models/Wallet/DSAccount.h
@@ -289,9 +289,6 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 // returns the fee for the given transaction if all its inputs are from wallet transactions, UINT64_MAX otherwise
 - (uint64_t)feeForTransaction:(DSTransaction *)transaction;
 
-// historical wallet balance after the given transaction, or current balance if transaction is not registered in wallet
-- (uint64_t)balanceAfterTransaction:(DSTransaction *)transaction;
-
 - (void)chainUpdatedBlockHeight:(int32_t)height;
 
 - (NSArray *)setBlockHeight:(int32_t)height andTimestamp:(NSTimeInterval)timestamp forTransactionHashes:(NSArray *)txHashes;


### PR DESCRIPTION
## Issue being fixed or feature implemented
`sortTransactions` method causes memory spikes on start and deadlocks during sync

## What was done?
- Fix memory issues in `sortTransactions`
- Simplify `sortTransactions` to avoid long locks
- Remove dead code


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined wallet balance management by removing redundant historical balance tracking.
	- Enhanced transaction processing with updated sorting for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->