### PR TITLE
fix: inform UI of a double spend transactions

### DIFF
--- a/DashSync/shared/Models/Entities/DSFriendRequestEntity+CoreDataClass.m
+++ b/DashSync/shared/Models/Entities/DSFriendRequestEntity+CoreDataClass.m
@@ -88,7 +88,7 @@
 
     NSAssert([paymentRequest isValidAsNonDashpayPaymentRequest], @"Payment request must be valid");
 
-    // TODO: mixed only?
+    // TODO: MOCK_DASHPAY mixed only?
     [account.wallet.chain.chainManager.transactionManager confirmPaymentRequest:paymentRequest
                                                     usingUserBlockchainIdentity:nil
                                                                     fromAccount:account

--- a/DashSync/shared/Models/Wallet/DSAccount.h
+++ b/DashSync/shared/Models/Wallet/DSAccount.h
@@ -289,9 +289,6 @@ FOUNDATION_EXPORT NSString *_Nonnull const DSAccountNewAccountShouldBeAddedFromT
 // returns the fee for the given transaction if all its inputs are from wallet transactions, UINT64_MAX otherwise
 - (uint64_t)feeForTransaction:(DSTransaction *)transaction;
 
-// historical wallet balance after the given transaction, or current balance if transaction is not registered in wallet
-- (uint64_t)balanceAfterTransaction:(DSTransaction *)transaction;
-
 - (void)chainUpdatedBlockHeight:(int32_t)height;
 
 - (NSArray *)setBlockHeight:(int32_t)height andTimestamp:(NSTimeInterval)timestamp forTransactionHashes:(NSArray *)txHashes;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Double spent is not displayed in UI.

## What was done?
Post `DSTransactionManagerTransactionStatusDidChangeNotification` for double spent or unconfirmed transactions. The UI will then check the status of the transaction and change its status if its `invalid`.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced real-time notifications ensure timely updates on transaction status changes, including published, rejected, and unrelayed transactions.

- **Refactor**
  - Streamlined friend request handling and wallet balance management by removing legacy methods and historical balance tracking for a more efficient processing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->