### PR TITLE
fix(coinjoin): finishing state

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) DSCoinJoinWrapper *wrapper;
 @property (nonatomic, readonly) BOOL isWaitingForNewBlock;
 @property (atomic) BOOL isMixing;
+@property (atomic) BOOL isShuttingDown;
 @property (readonly) BOOL isChainSynced;
 
 + (instancetype)sharedInstanceForChain:(DSChain *)chain;
@@ -90,6 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)minimumAnonymizableBalanceWithCompletion:(void (^)(uint64_t balance))completion;
 - (void)updateOptionsWithAmount:(uint64_t)amount;
 - (void)updateOptionsWithEnabled:(BOOL)isEnabled;
+- (void)initiateShutdown;
 
 // Events
 - (void)onSessionComplete:(int32_t)baseId clientSessionId:(UInt256)clientId denomination:(uint32_t)denom poolState:(PoolState)state poolMessage:(PoolMessage)message poolStatus:(PoolStatus)status ipAddress:(UInt128)address isJoined:(BOOL)joined;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
@@ -256,6 +256,7 @@ static dispatch_once_t managerChainToken = 0;
 #else
         DSLog(@"[%@] CoinJoin tx: Mixing Transaction: %@", self.chain.name, @"<REDACTED>");
 #endif
+        [self.wrapper unlockOutputs:lastTransaction];
         [self onTransactionProcessed:lastTransaction.txHash type:CoinJoinTransactionType_Mixing];
     }
 }

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)refreshUnusedKeys;
 - (BOOL)isDenominatedAmount:(uint64_t)amount;
 - (BOOL)isFullyMixed:(DSUTXO)utxo;
+- (void)initiateShutdown;
 + (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction;
 + (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction account:(DSAccount *)account;
 - (void)unlockOutputs:(DSTransaction *)transaction;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isFullyMixed:(DSUTXO)utxo;
 + (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction;
 + (CoinJoinTransactionType)coinJoinTxTypeForTransaction:(DSTransaction *)transaction account:(DSAccount *)account;
+- (void)unlockOutputs:(DSTransaction *)transaction;
 - (uint64_t)getAnonymizableBalance:(BOOL)skipDenominated skipUnconfirmed:(BOOL)skipUnconfirmed;
 - (uint64_t)getSmallestDenomination;
 - (void)updateOptions:(CoinJoinClientOptions *)options;

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -91,8 +91,14 @@
 - (void)doMaintenance {
     @synchronized (self) {
         Balance *balance = [[self.manager getBalance] ffi_malloc];
-        do_maintenance(_clientManager, *balance);
+        do_maintenance(self.clientManager, *balance);
         [DSCoinJoinBalance ffi_free:balance];
+    }
+}
+
+- (void)initiateShutdown {
+    @synchronized (self) {
+        initiate_shutdown(self.clientManager);
     }
 }
 
@@ -179,9 +185,11 @@
 }
 
 - (void)unlockOutputs:(DSTransaction *)transaction {
-    Transaction *tx = [transaction ffi_malloc:transaction.chain.chainType];
-    unlock_outputs(self.clientManager, tx);
-    [DSTransaction ffi_free:tx];
+    @synchronized (self) {
+        Transaction *tx = [transaction ffi_malloc:transaction.chain.chainType];
+        unlock_outputs(self.clientManager, tx);
+        [DSTransaction ffi_free:tx];
+    }
 }
 
 - (uint64_t)getAnonymizableBalance:(BOOL)skipDenominated skipUnconfirmed:(BOOL)skipUnconfirmed {

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinWrapper.m
@@ -145,14 +145,14 @@
 - (void)notifyNewBestBlock:(DSBlock *)block {
     if (block) {
         @synchronized (self) {
-            notify_new_best_block(_clientManager, (uint8_t (*)[32])(block.blockHash.u8), block.height);
+            notify_new_best_block(self.clientManager, (uint8_t (*)[32])(block.blockHash.u8), block.height);
         }
     }
 }
 
 - (BOOL)isMixingFeeTx:(UInt256)txId {
     @synchronized (self) {
-        return is_mixing_fee_tx(_clientManager, (uint8_t (*)[32])(txId.u8));
+        return is_mixing_fee_tx(self.clientManager, (uint8_t (*)[32])(txId.u8));
     }
 }
 
@@ -178,9 +178,15 @@
     return type;
 }
 
+- (void)unlockOutputs:(DSTransaction *)transaction {
+    Transaction *tx = [transaction ffi_malloc:transaction.chain.chainType];
+    unlock_outputs(self.clientManager, tx);
+    [DSTransaction ffi_free:tx];
+}
+
 - (uint64_t)getAnonymizableBalance:(BOOL)skipDenominated skipUnconfirmed:(BOOL)skipUnconfirmed {
     @synchronized (self) {
-        return get_anonymizable_balance(_clientManager, skipDenominated, skipUnconfirmed);
+        return get_anonymizable_balance(self.clientManager, skipDenominated, skipUnconfirmed);
     }
 }
 

--- a/DashSync/shared/Models/Network/DSPeer.m
+++ b/DashSync/shared/Models/Network/DSPeer.m
@@ -1040,7 +1040,7 @@
     if (count == 0) {
         DSLogWithLocation(self, @"Got empty Inv message");
     }
-    if (count > 0 && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_MasternodePing) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_MasternodePaymentVote) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_MasternodeVerify) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_GovernanceObjectVote) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_DSTx)) {
+    if (count > 0 && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_MasternodePing) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_MasternodePaymentVote) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_MasternodeVerify) && ([message UInt32AtOffset:l.unsignedIntegerValue] != DSInvType_GovernanceObjectVote)) {
         DSLogWithLocation(self, @"got inv with %u item%@ (first item %@ with hash %@/%@)", (int)count, count == 1 ? @"" : @"s", [self nameOfInvMessage:[message UInt32AtOffset:l.unsignedIntegerValue]], [NSData dataWithUInt256:[message UInt256AtOffset:l.unsignedIntegerValue + sizeof(uint32_t)]].hexString, [NSData dataWithUInt256:[message UInt256AtOffset:l.unsignedIntegerValue + sizeof(uint32_t)]].reverse.hexString);
     }
 #endif
@@ -1063,7 +1063,7 @@
         switch (type) {
             case DSInvType_Tx: [txHashes addObject:uint256_obj(hash)]; break;
             case DSInvType_TxLockRequest: [txHashes addObject:uint256_obj(hash)]; break;
-            case DSInvType_DSTx: break;
+            case DSInvType_DSTx: [txHashes addObject:uint256_obj(hash)]; break;
             case DSInvType_TxLockVote: break;
             case DSInvType_InstantSendDeterministicLock: [instantSendLockDHashes addObject:uint256_obj(hash)]; break;
             case DSInvType_InstantSendLock: [instantSendLockHashes addObject:uint256_obj(hash)]; break;


### PR DESCRIPTION
## Issue being fixed or feature implemented
After CoinJoin is turned off, some inputs might still be mixing, which can cause double-spend.

## What was done?
- Process DSTX message properly to speed up mixing transactions appearing
- Add a finishing state so the app can wait until full shutdown.

## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone