### PR TITLE
feat: allow the client to check if an amount is denominated

### DIFF
--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.h
@@ -111,6 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateOptionsWithAmount:(uint64_t)amount;
 - (void)updateOptionsWithEnabled:(BOOL)isEnabled;
 - (void)initiateShutdown;
++ (BOOL)isDenominatedAmount:(uint64_t)amount;
 
 // Events
 - (void)onSessionComplete:(int32_t)baseId

--- a/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
+++ b/DashSync/shared/Models/CoinJoin/DSCoinJoinManager.m
@@ -732,6 +732,10 @@ static dispatch_once_t managerChainToken = 0;
     return outputs;
 }
 
++ (BOOL)isDenominatedAmount:(uint64_t)amount {
+    return is_denominated_amount(amount);
+}
+
 - (BOOL)isCoinJoinOutput:(DSTransactionOutput *)output utxo:(DSUTXO)utxo {
     if (![self.wrapper isDenominatedAmount:output.amount]) {
         return false;


### PR DESCRIPTION
## Issue being fixed or feature implemented
For the invite screen changes, we need a method to check if `assetLockTx` is mixed or not.

## What was done?
- Expose appropriate CoinJoin methods.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone