### PR TITLE
fix: don't cache recent transactions during syncing

### DIFF
--- a/DashSync/shared/Models/Transactions/Base/DSTransaction.m
+++ b/DashSync/shared/Models/Transactions/Base/DSTransaction.m
@@ -360,7 +360,12 @@
         amount = 0;
     }
 
-    self.cachedDashAmount = amount;
+    BOOL isChainSynced = self.chain.chainManager.syncPhase == DSChainSyncPhase_Synced;
+    
+    if (isChainSynced || self.timestamp + (30 * 60) < [[NSDate date] timeIntervalSince1970]) {
+        // Don't cache recent transactions if still syncing
+        self.cachedDashAmount = amount;
+    }
     
     return amount;
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Recent changes to transaction caching introduce a problem: if the transaction is cached during sync, its information can be invalid because the wallet is missing most of the required information.

## What was done?
- Don't cache transactions if the wallet is syncing and the transaction is recent.

## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved caching behavior for transaction amounts to ensure more accurate and up-to-date values, especially during chain synchronization or for recent transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->